### PR TITLE
Removed extra HTTPS from Link Mauve's implementation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Attempts to rewrite the OpenGL rendering code to be on-par with the standard Ino
 
 ## Implementation
 
-Inox2D is currently a bit of a merge between [the original Inochi2D implementation](https://github.com/Inochi2D/inochi2d) in D and [Link Mauve's implementation](https://https://linkmauve.fr/dev/inochi2d/) in Rust (the [inochi2d](https://crates.io/crates/inochi2d) crate). The original is the standard, while Link's is a reverse-engineered and optimized implementation, but lacking the remaining core features that need to be implemented. His code is much simpler, but also not extensible (nodes are managed with an enum), so users of the library wouldn't be able to create custom nodes.
+Inox2D is currently a bit of a merge between [the original Inochi2D implementation](https://github.com/Inochi2D/inochi2d) in D and [Link Mauve's implementation](https://linkmauve.fr/dev/inochi2d/) in Rust (the [inochi2d](https://crates.io/crates/inochi2d) crate). The original is the standard, while Link's is a reverse-engineered and optimized implementation, but lacking the remaining core features that need to be implemented. His code is much simpler, but also not extensible (nodes are managed with an enum), so users of the library wouldn't be able to create custom nodes.
 
 Inox2D is designed to be extensible. Nodes are extensible through a generic `InoxData<T>` enum which has a `Custom(T)` variant. Every other part of the library accounts for it: the OpenGL renderer accepts any struct that implements the `CustomRenderer` trait to be able to render your custom nodes, and the deserialization functions accept generic `Fn`s for deserialization of custom nodes when it is relevant.
 


### PR DESCRIPTION
Made a fix since I came across this while browsing the page and this is probably trivial to make as an issue.
