### PR TITLE
Fix macOS (and Windows) context creation

### DIFF
--- a/src/renderers/opengl/mod.rs
+++ b/src/renderers/opengl/mod.rs
@@ -406,6 +406,8 @@ where
     fn render_composite(&self, node: &ExtInoxNode<T>, composite: &Composite) {
         let name = &node.name;
         let gl = &self.gl;
+
+        #[cfg(not(target_os = "macos"))]
         unsafe { gl.push_debug_group(glow::DEBUG_SOURCE_APPLICATION, 0, name) };
 
         #[cfg(feature = "owo")]
@@ -429,6 +431,7 @@ where
         }
         eprintln!("]");
 
+        #[cfg(not(target_os = "macos"))]
         unsafe { gl.pop_debug_group() };
     }
 
@@ -438,6 +441,8 @@ where
     fn render_part(&self, node: &ExtInoxNode<T>, part: &Part, disable_stencil: bool) {
         let name = &node.name;
         let gl = &self.gl;
+        
+        #[cfg(not(target_os = "macos"))]
         unsafe { gl.push_debug_group(glow::DEBUG_SOURCE_APPLICATION, 0, name) };
 
         #[cfg(feature = "owo")]
@@ -472,6 +477,7 @@ where
             );
         }
 
+        #[cfg(not(target_os = "macos"))]
         unsafe { gl.pop_debug_group() };
     }
 


### PR DESCRIPTION
Fixes context creation by conditionally using Cgl on macOS and Wgl on Windows. Additionally changes the target OpenGL version to Desktop OpenGL 3.1 which is better suited as it's more widely supported.

macOS does not have the debug callback extension, so this is disabled with a cfg macro