### PR TITLE
Correct "Add missing license and copyright"

### DIFF
--- a/src/renderers/opengl/gl_buffer.rs
+++ b/src/renderers/opengl/gl_buffer.rs
@@ -1,9 +1,3 @@
-// Copyright (c) 2022 Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 use std::ops::{Deref, DerefMut};
 
 use glow::HasContext;


### PR DESCRIPTION
- Related to Inochi2D/inox2d#21.

I have no problem putting the additional license where it is needed. But where it is not, it should not be there.
Also, I am unsure what to do about the copyright of the OpenGL renderer. It did start very similarly to @linkmauve's implementation, but it is shifting away from it more and more and is already at a state where it is quite different, especially after implementing an MVP.

Putting both licenses and copyright it to both Link and me seems to be where this leads, but I don't know if it makes sense legally.
I don't want to spend too much time on this, after all it's still all open-source work. But the Mozilla license is fundamentally incompatible with Inochi2D, so I'd like to avoid as much of it as possible.