### PR TITLE
Split puppet.rs into a module

### DIFF
--- a/src/puppet/display.rs
+++ b/src/puppet/display.rs
@@ -1,0 +1,113 @@
+use std::fmt;
+use crate::puppet::writeln_opt;
+
+use crate::puppet::*;
+
+impl fmt::Display for PuppetAllowedUsers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PuppetAllowedUsers::OnlyAuthor => "only author",
+                PuppetAllowedUsers::OnlyLicensee => "only licensee",
+                PuppetAllowedUsers::Everyone => "Everyone",
+            }
+        )
+    }
+}
+
+impl fmt::Display for PuppetAllowedRedistribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PuppetAllowedRedistribution::Prohibited => "prohibited",
+                PuppetAllowedRedistribution::ViralLicense => "viral license",
+                PuppetAllowedRedistribution::CopyleftLicense => "copyleft license",
+            }
+        )
+    }
+}
+
+impl fmt::Display for PuppetAllowedModification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PuppetAllowedModification::Prohibited => "prohibited",
+                PuppetAllowedModification::AllowPersonal => "allow personal",
+                PuppetAllowedModification::AllowRedistribute => "allow redistribute",
+            }
+        )
+    }
+}
+
+impl fmt::Display for PuppetUsageRights {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "| allowed users:  {}", self.allowed_users)?;
+        writeln!(f, "| violence:       {}", allowed_bool(self.allow_violence))?;
+        writeln!(f, "| sexual:         {}", allowed_bool(self.allow_sexual))?;
+        writeln!(
+            f,
+            "| commercial:     {}",
+            allowed_bool(self.allow_commercial)
+        )?;
+        writeln!(f, "| redistribution: {}", self.allow_redistribution)?;
+        writeln!(f, "| modification:   {}", self.allow_modification)?;
+        writeln!(
+            f,
+            "| attribution: {}",
+            if self.require_attribution {
+                "required"
+            } else {
+                "not required"
+            }
+        )
+    }
+}
+
+impl fmt::Display for PuppetMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name {
+            Some(ref name) => writeln_opt(f, "Name", &Some(name))?,
+            None => {
+                let no_name = "(No Name)";
+                #[cfg(feature = "owo")]
+                let no_name = {
+                    use owo_colors::OwoColorize;
+                    no_name.dimmed()
+                };
+                writeln!(f, "{no_name}")?
+            }
+        }
+
+        writeln_opt(f, "Version", &Some(&self.version))?;
+        writeln_opt(f, "Rigger", &self.rigger)?;
+        writeln_opt(f, "Artist", &self.artist)?;
+
+        if let Some(ref rights) = self.rights {
+            writeln!(f, "Rights:")?;
+            #[cfg(feature = "owo")]
+            let rights = {
+                use owo_colors::OwoColorize;
+                rights.yellow()
+            };
+            writeln!(f, "{rights}")?;
+        }
+
+        writeln_opt(f, "Copyright", &self.copyright)?;
+        writeln_opt(f, "License URL", &self.license_url)?;
+        writeln_opt(f, "Contact", &self.contact)?;
+        writeln_opt(f, "Reference", &self.reference)?;
+        writeln_opt(f, "Thumbnail ID", &self.thumbnail_id)?;
+
+        writeln_opt(
+            f,
+            "Preserve pixels",
+            &Some(if self.preserve_pixels { "yes" } else { "no" }),
+        )
+    }
+}

--- a/src/puppet/mod.rs
+++ b/src/puppet/mod.rs
@@ -1,11 +1,11 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::fmt;
 
 use crate::nodes::node_tree::InoxNodeTree;
 use crate::params::Param;
 
+// See this issue so we can maybe remove the TryFrom implementations
+// in the future: https://github.com/Peternator7/strum/issues/13
 mod display;
 
 /// Who is allowed to use the puppet?

--- a/src/puppet/mod.rs
+++ b/src/puppet/mod.rs
@@ -6,6 +6,8 @@ use std::fmt;
 use crate::nodes::node_tree::InoxNodeTree;
 use crate::params::Param;
 
+mod display;
+
 /// Who is allowed to use the puppet?
 #[derive(Clone, Copy, Debug, Default)]
 pub enum PuppetAllowedUsers {
@@ -16,20 +18,6 @@ pub enum PuppetAllowedUsers {
     OnlyLicensee,
     /// Everyone may use the model.
     Everyone,
-}
-
-impl fmt::Display for PuppetAllowedUsers {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                PuppetAllowedUsers::OnlyAuthor => "only author",
-                PuppetAllowedUsers::OnlyLicensee => "only licensee",
-                PuppetAllowedUsers::Everyone => "Everyone",
-            }
-        )
-    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -65,20 +53,6 @@ pub enum PuppetAllowedRedistribution {
     CopyleftLicense,
 }
 
-impl fmt::Display for PuppetAllowedRedistribution {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                PuppetAllowedRedistribution::Prohibited => "prohibited",
-                PuppetAllowedRedistribution::ViralLicense => "viral license",
-                PuppetAllowedRedistribution::CopyleftLicense => "copyleft license",
-            }
-        )
-    }
-}
-
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("Unknown allowed redistribution {0:?}")]
 pub struct UnknownPuppetAllowedRedistributionError(String);
@@ -107,20 +81,6 @@ pub enum PuppetAllowedModification {
     /// Modification is allowed with redistribution, see
     /// `allowed_redistribution` for redistribution terms.
     AllowRedistribute,
-}
-
-impl fmt::Display for PuppetAllowedModification {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                PuppetAllowedModification::Prohibited => "prohibited",
-                PuppetAllowedModification::AllowPersonal => "allow personal",
-                PuppetAllowedModification::AllowRedistribute => "allow redistribute",
-            }
-        )
-    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -167,30 +127,6 @@ fn allowed_bool(value: bool) -> &'static str {
     }
 }
 
-impl fmt::Display for PuppetUsageRights {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "| allowed users:  {}", self.allowed_users)?;
-        writeln!(f, "| violence:       {}", allowed_bool(self.allow_violence))?;
-        writeln!(f, "| sexual:         {}", allowed_bool(self.allow_sexual))?;
-        writeln!(
-            f,
-            "| commercial:     {}",
-            allowed_bool(self.allow_commercial)
-        )?;
-        writeln!(f, "| redistribution: {}", self.allow_redistribution)?;
-        writeln!(f, "| modification:   {}", self.allow_modification)?;
-        writeln!(
-            f,
-            "| attribution: {}",
-            if self.require_attribution {
-                "required"
-            } else {
-                "not required"
-            }
-        )
-    }
-}
-
 /// Puppet meta information.
 #[derive(Clone, Debug)]
 pub struct PuppetMeta {
@@ -234,49 +170,6 @@ fn writeln_opt<T: fmt::Display>(
         writeln!(f, "{field_name}{value}")?;
     }
     Ok(())
-}
-
-impl fmt::Display for PuppetMeta {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.name {
-            Some(ref name) => writeln_opt(f, "Name", &Some(name))?,
-            None => {
-                let no_name = "(No Name)";
-                #[cfg(feature = "owo")]
-                let no_name = {
-                    use owo_colors::OwoColorize;
-                    no_name.dimmed()
-                };
-                writeln!(f, "{no_name}")?
-            }
-        }
-
-        writeln_opt(f, "Version", &Some(&self.version))?;
-        writeln_opt(f, "Rigger", &self.rigger)?;
-        writeln_opt(f, "Artist", &self.artist)?;
-
-        if let Some(ref rights) = self.rights {
-            writeln!(f, "Rights:")?;
-            #[cfg(feature = "owo")]
-            let rights = {
-                use owo_colors::OwoColorize;
-                rights.yellow()
-            };
-            writeln!(f, "{rights}")?;
-        }
-
-        writeln_opt(f, "Copyright", &self.copyright)?;
-        writeln_opt(f, "License URL", &self.license_url)?;
-        writeln_opt(f, "Contact", &self.contact)?;
-        writeln_opt(f, "Reference", &self.reference)?;
-        writeln_opt(f, "Thumbnail ID", &self.thumbnail_id)?;
-
-        writeln_opt(
-            f,
-            "Preserve pixels",
-            &Some(if self.preserve_pixels { "yes" } else { "no" }),
-        )
-    }
 }
 
 impl Default for PuppetMeta {


### PR DESCRIPTION
Previously, everything regarding puppet was in puppet.rs. Now, it's split up into puppet/ so that it's easier to manage and search though.

The API should be the same, save for the enum modifications made.

The modifications to the enums are meant to better reflect their usage, and real-world examples. For example, instead of ViralLicense, it's SameLicense. Instead of Copyleft, it's Permissive.