### PR TITLE
WGPU renderer refactor

### DIFF
--- a/examples/common/opengl.rs
+++ b/examples/common/opengl.rs
@@ -1,0 +1,120 @@
+use std::env;
+use std::error::Error;
+use std::ffi::CString;
+use std::num::NonZeroU32;
+
+use glow::HasContext;
+use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext, Version};
+use glutin::display::{Display, GetGlDisplay};
+use glutin::prelude::{GlConfig, GlDisplay, NotCurrentGlContextSurfaceAccessor};
+use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
+use glutin_winit::ApiPrefence;
+use raw_window_handle::HasRawWindowHandle;
+use tracing::{debug, error, info, warn};
+use winit::event_loop::EventLoop;
+use winit::window::Window;
+
+pub struct App {
+    pub gl: glow::Context,
+    pub gl_ctx: PossiblyCurrentContext,
+    pub gl_surface: Surface<WindowSurface>,
+    pub gl_display: Display,
+    pub window: Window,
+    pub events: EventLoop<()>,
+}
+
+pub fn launch_opengl_window() -> Result<App, Box<dyn Error>> {
+    if cfg!(target_os = "linux") {
+        // disables vsync sometimes on x11
+        if env::var("vblank_mode").is_err() {
+            env::set_var("vblank_mode", "0");
+        }
+    }
+
+    let events = winit::event_loop::EventLoop::new();
+
+    let window_builder = winit::window::WindowBuilder::new()
+        .with_transparent(true)
+        .with_resizable(true)
+        .with_inner_size(winit::dpi::PhysicalSize::new(600, 800))
+        .with_title("Render Inochi2D Puppet (OpenGL)");
+
+    let (window, gl_config) = glutin_winit::DisplayBuilder::new()
+        .with_preference(ApiPrefence::FallbackEgl)
+        .with_window_builder(Some(window_builder))
+        .build(&events, <_>::default(), |configs| {
+            configs
+                .filter(|c| c.srgb_capable())
+                .max_by_key(|c| c.num_samples())
+                .unwrap()
+        })?;
+
+    let window = window.unwrap(); // set in display builder
+    let raw_window_handle = window.raw_window_handle();
+    let gl_display = gl_config.display();
+
+    let context_attributes = ContextAttributesBuilder::new()
+        .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 1))))
+        .with_profile(glutin::context::GlProfile::Core)
+        .build(Some(raw_window_handle));
+
+    let dimensions = window.inner_size();
+
+    let (gl_surface, gl_ctx) = {
+        let attrs = SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new().build(
+            raw_window_handle,
+            NonZeroU32::new(dimensions.width).unwrap(),
+            NonZeroU32::new(dimensions.height).unwrap(),
+        );
+
+        let surface = unsafe { gl_display.create_window_surface(&gl_config, &attrs)? };
+        let context = unsafe { gl_display.create_context(&gl_config, &context_attributes)? }
+            .make_current(&surface)?;
+        (surface, context)
+    };
+
+    // Load the OpenGL function pointers
+    let gl = unsafe {
+        glow::Context::from_loader_function(|symbol| {
+            gl_display.get_proc_address(&CString::new(symbol).unwrap()) as *const _
+        })
+    };
+
+    // Check for "GL_KHR_debug" support (not present on Apple *OS).
+    if gl.supported_extensions().contains("GL_KHR_debug") {
+        unsafe {
+            gl.debug_message_callback(|_src, ty, _id, sevr, msg| {
+                let ty = match ty {
+                    glow::DEBUG_TYPE_ERROR => "Error: ",
+                    glow::DEBUG_TYPE_DEPRECATED_BEHAVIOR => "Deprecated Behavior: ",
+                    glow::DEBUG_TYPE_MARKER => "Marker: ",
+                    glow::DEBUG_TYPE_OTHER => "",
+                    glow::DEBUG_TYPE_POP_GROUP => "Pop Group: ",
+                    glow::DEBUG_TYPE_PORTABILITY => "Portability: ",
+                    glow::DEBUG_TYPE_PUSH_GROUP => "Push Group: ",
+                    glow::DEBUG_TYPE_UNDEFINED_BEHAVIOR => "Undefined Behavior: ",
+                    glow::DEBUG_TYPE_PERFORMANCE => "Performance: ",
+                    ty => unreachable!("unknown debug type {ty}"),
+                };
+                match sevr {
+                    glow::DEBUG_SEVERITY_NOTIFICATION => debug!(target: "opengl", "{ty}{msg}"),
+                    glow::DEBUG_SEVERITY_LOW => info!(target: "opengl", "{ty}{msg}"),
+                    glow::DEBUG_SEVERITY_MEDIUM => warn!(target: "opengl", "{ty}{msg}"),
+                    glow::DEBUG_SEVERITY_HIGH => error!(target: "opengl", "{ty}{msg}"),
+                    sevr => unreachable!("unknown debug severity {sevr}"),
+                };
+            });
+
+            gl.enable(glow::DEBUG_OUTPUT);
+        }
+    }
+
+    Ok(App {
+        gl,
+        gl_ctx,
+        gl_surface,
+        gl_display,
+        window,
+        events,
+    })
+}

--- a/examples/common/scene.rs
+++ b/examples/common/scene.rs
@@ -1,0 +1,92 @@
+//! A nice scene controller to smoothly move around in the window.
+
+use std::time::Instant;
+
+use glam::{vec2, Vec2};
+use inox2d::math::camera::Camera;
+use winit::event::{ElementState, MouseScrollDelta, WindowEvent};
+use winit::window::Window;
+
+pub struct ExampleSceneController {
+    // for camera position and mouse interactions
+    camera_pos: Vec2,
+    mouse_pos: Vec2,
+    mouse_pos_held: Vec2,
+    mouse_state: ElementState,
+
+    // for smooth scrolling
+    pub scroll_speed: f32,
+    hard_scale: Vec2,
+
+    // for FPS-independent interactions
+    start: Instant,
+    prev_elapsed: f32,
+    current_elapsed: f32,
+}
+
+impl ExampleSceneController {
+    pub fn new(camera: &Camera, scroll_speed: f32) -> Self {
+        Self {
+            camera_pos: camera.position,
+            mouse_pos: Vec2::default(),
+            mouse_pos_held: Vec2::default(),
+            mouse_state: ElementState::Released,
+            scroll_speed,
+            hard_scale: camera.scale,
+            start: Instant::now(),
+            prev_elapsed: 0.0,
+            current_elapsed: 0.0,
+        }
+    }
+
+    pub fn update(&mut self, camera: &mut Camera) {
+        // Smooth scrolling
+        let time_delta = self.current_elapsed - self.prev_elapsed;
+        camera.scale = camera.scale + time_delta.powf(0.6) * (self.hard_scale - camera.scale);
+
+        // Mouse dragging
+        if self.mouse_state == ElementState::Pressed {
+            camera.position =
+                self.camera_pos + (self.mouse_pos - self.mouse_pos_held) / camera.scale;
+        }
+
+        // Frame interval
+        self.prev_elapsed = self.current_elapsed;
+        self.current_elapsed = self.start.elapsed().as_secs_f32();
+    }
+
+    pub fn interact(&mut self, window: &Window, event: &WindowEvent, camera: &Camera) {
+        match event {
+            WindowEvent::CursorMoved { position, .. } => {
+                self.mouse_pos = vec2(position.x as f32, position.y as f32);
+
+                if self.mouse_state == ElementState::Pressed {
+                    window.request_redraw();
+                }
+            }
+            WindowEvent::MouseInput { state, .. } => {
+                self.mouse_state = *state;
+                if self.mouse_state == ElementState::Pressed {
+                    self.mouse_pos_held = self.mouse_pos;
+                    self.camera_pos = camera.position;
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                // Handle mouse wheel (zoom)
+                let my = match delta {
+                    MouseScrollDelta::LineDelta(_, y) => *y * 12.,
+                    MouseScrollDelta::PixelDelta(pos) => pos.y as f32,
+                };
+
+                self.hard_scale *= 2_f32.powf(self.scroll_speed * my * 0.1);
+
+                window.request_redraw();
+            }
+            _ => (),
+        }
+    }
+
+    pub fn current_elapsed(&self) -> f32 {
+        self.current_elapsed
+    }
+}

--- a/examples/render_opengl.rs
+++ b/examples/render_opengl.rs
@@ -1,41 +1,23 @@
-use std::{
-    env,
-    error::Error,
-    ffi::CString,
-    fs::File,
-    io::{BufReader, Read},
-    num::NonZeroU32,
-    time::Instant,
-};
-
-use glam::{uvec2, vec2, Vec2};
-use glow::HasContext;
-
-use glutin::{
-    context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext, Version},
-    display::Display,
-    display::GetGlDisplay,
-    prelude::{GlConfig, GlDisplay, NotCurrentGlContextSurfaceAccessor},
-    surface::{GlSurface, Surface, SurfaceAttributesBuilder, WindowSurface},
-};
-
-use glutin_winit::ApiPrefence;
-use inox2d::{formats::inp::parse_inp, render::opengl::OpenglRenderer};
-use raw_window_handle::HasRawWindowHandle;
-
-use tracing::{debug, error, info, warn};
-
-use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
-
-use winit::{
-    event::{ElementState, Event, KeyboardInput, MouseScrollDelta, VirtualKeyCode, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
-    window::Window,
-};
-
 use std::path::PathBuf;
+use std::{error::Error, fs, num::NonZeroU32};
+
+use inox2d::{formats::inp::parse_inp, render::opengl::OpenglRenderer};
 
 use clap::Parser;
+use glam::{uvec2, Vec2};
+use glutin::surface::GlSurface;
+use tracing::{debug, info};
+use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+
+use crate::opengl::{launch_opengl_window, App};
+use crate::scene::ExampleSceneController;
+
+#[path ="./common/opengl.rs"]
+mod opengl;
+
+#[path ="./common/scene.rs"]
+mod scene;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -53,22 +35,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     info!("Parsing puppet");
-    let data = {
-        let file = File::open(cli.inp_path).unwrap();
-        let mut file = BufReader::new(file);
-        let mut data = Vec::new();
-        file.read_to_end(&mut data).unwrap();
-        data
-    };
+
+    let data = fs::read(cli.inp_path).unwrap();
     let model = parse_inp(data.as_slice()).unwrap();
     let puppet = model.puppet;
     info!(
         "Successfully parsed puppet: {}",
-        puppet
-            .meta
-            .name
-            .as_deref()
-            .unwrap_or("<no puppet name specified in file>")
+        (puppet.meta.name.as_deref()).unwrap_or("<no puppet name specified in file>")
     );
 
     info!("Setting up windowing and OpenGL");
@@ -89,21 +62,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     renderer.camera.scale = Vec2::splat(0.15);
     info!("Inox2D renderer initialized");
 
-    // variables and state for camera position and mouse interactions
-    let mut camera_pos = Vec2::ZERO;
-    let mut mouse_pos = Vec2::ZERO;
-    let mut mouse_pos_held = mouse_pos;
-    let mut mouse_state = ElementState::Released;
-
-    // variables and state for smooth scrolling
-    let scroll_speed: f32 = 3.0;
-    let mut hard_scale = renderer.camera.scale;
-
-    // variables and state for FPS-independent interactions
-    let start = Instant::now();
-    let mut prev_elapsed: f32 = 0.0;
-    let mut current_elapsed: f32 = 0.0;
-
+    let mut scene_ctrl = ExampleSceneController::new(&renderer.camera, 0.5);
     let mut puppet = puppet;
 
     // Event loop
@@ -117,24 +76,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         match event {
             Event::RedrawRequested(_) => {
                 debug!("Redrawing");
-
-                // Smooth scrolling
-                {
-                    let time_delta = current_elapsed - prev_elapsed;
-                    renderer.camera.scale = renderer.camera.scale
-                        + time_delta.powf(0.6) * (hard_scale - renderer.camera.scale);
-                }
-
-                // Mouse dragging
-                if mouse_state == ElementState::Pressed {
-                    renderer.camera.position =
-                        camera_pos + (mouse_pos - mouse_pos_held) / renderer.camera.scale;
-                }
-
+                scene_ctrl.update(&mut renderer.camera);
+                
                 renderer.clear();
 
                 puppet.begin_set_params();
-                let t = current_elapsed;
+                let t = scene_ctrl.current_elapsed();
                 puppet.set_param("Head:: Yaw-Pitch", Vec2::new(t.cos(), t.sin()));
                 puppet.end_set_params();
 
@@ -142,9 +89,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 gl_surface.swap_buffers(&gl_ctx).unwrap();
                 window.request_redraw();
-
-                prev_elapsed = current_elapsed;
-                current_elapsed = start.elapsed().as_secs_f32();
             }
             Event::WindowEvent { ref event, .. } => match event {
                 WindowEvent::Resized(physical_size) => {
@@ -157,166 +101,25 @@ fn main() -> Result<(), Box<dyn Error>> {
                     );
                     window.request_redraw();
                 }
-                WindowEvent::CursorMoved { position, .. } => {
-                    mouse_pos = vec2(position.x as f32, position.y as f32);
-
-                    if mouse_state == ElementState::Pressed {
-                        window.request_redraw();
-                    }
+                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::Escape),
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => {
+                    info!("There is an Escape D:");
+                    control_flow.set_exit();
                 }
-                WindowEvent::MouseInput { state, .. } => {
-                    mouse_state = *state;
-                    if mouse_state == ElementState::Pressed {
-                        mouse_pos_held = mouse_pos;
-                        camera_pos = renderer.camera.position;
-                    }
-                }
-                WindowEvent::MouseWheel { delta, .. } => {
-                    // Handle mouse wheel (zoom)
-                    let my = match delta {
-                        MouseScrollDelta::LineDelta(_, y) => *y * 12.,
-                        MouseScrollDelta::PixelDelta(pos) => pos.y as f32,
-                    };
-
-                    let time_delta = current_elapsed - prev_elapsed;
-                    hard_scale *= 10_f32.powf(scroll_speed * time_delta * my);
-
-                    window.request_redraw();
-                }
-                _ => (),
+                _ => scene_ctrl.interact(&window, event, &renderer.camera),
             },
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
             _ => (),
         }
-
-        handle_close(event, control_flow);
     })
-}
-
-struct App {
-    pub gl: glow::Context,
-    pub gl_ctx: PossiblyCurrentContext,
-    pub gl_surface: Surface<WindowSurface>,
-    pub gl_display: Display,
-    pub window: Window,
-    pub events: EventLoop<()>,
-}
-
-fn launch_opengl_window() -> Result<App, Box<dyn Error>> {
-    if cfg!(target_os = "linux") {
-        // disables vsync sometimes on x11
-        if env::var("vblank_mode").is_err() {
-            env::set_var("vblank_mode", "0");
-        }
-    }
-
-    let events = winit::event_loop::EventLoop::new();
-
-    let window_builder = winit::window::WindowBuilder::new()
-        .with_transparent(true)
-        .with_resizable(true)
-        .with_inner_size(winit::dpi::PhysicalSize::new(600, 800))
-        .with_title("Render Inochi2D Puppet (OpenGL)");
-
-    let (window, gl_config) = glutin_winit::DisplayBuilder::new()
-        .with_preference(ApiPrefence::FallbackEgl)
-        .with_window_builder(Some(window_builder))
-        .build(&events, <_>::default(), |configs| {
-            configs
-                .filter(|c| c.srgb_capable())
-                .max_by_key(|c| c.num_samples())
-                .unwrap()
-        })?;
-
-    let window = window.unwrap(); // set in display builder
-    let raw_window_handle = window.raw_window_handle();
-    let gl_display = gl_config.display();
-
-    let context_attributes = ContextAttributesBuilder::new()
-        .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 1))))
-        .with_profile(glutin::context::GlProfile::Core)
-        .build(Some(raw_window_handle));
-
-    let dimensions = window.inner_size();
-
-    let (gl_surface, gl_ctx) = {
-        let attrs = SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new().build(
-            raw_window_handle,
-            NonZeroU32::new(dimensions.width).unwrap(),
-            NonZeroU32::new(dimensions.height).unwrap(),
-        );
-
-        let surface = unsafe { gl_display.create_window_surface(&gl_config, &attrs)? };
-        let context = unsafe { gl_display.create_context(&gl_config, &context_attributes)? }
-            .make_current(&surface)?;
-        (surface, context)
-    };
-
-    // Load the OpenGL function pointers
-    let gl = unsafe {
-        glow::Context::from_loader_function(|symbol| {
-            gl_display.get_proc_address(&CString::new(symbol).unwrap()) as *const _
-        })
-    };
-
-    // Check for "GL_KHR_debug" support (not present on Apple *OS).
-    if gl.supported_extensions().contains("GL_KHR_debug") {
-        unsafe {
-            gl.debug_message_callback(|_src, ty, _id, sevr, msg| {
-                let ty = match ty {
-                    glow::DEBUG_TYPE_ERROR => "Error: ",
-                    glow::DEBUG_TYPE_DEPRECATED_BEHAVIOR => "Deprecated Behavior: ",
-                    glow::DEBUG_TYPE_MARKER => "Marker: ",
-                    glow::DEBUG_TYPE_OTHER => "",
-                    glow::DEBUG_TYPE_POP_GROUP => "Pop Group: ",
-                    glow::DEBUG_TYPE_PORTABILITY => "Portability: ",
-                    glow::DEBUG_TYPE_PUSH_GROUP => "Push Group: ",
-                    glow::DEBUG_TYPE_UNDEFINED_BEHAVIOR => "Undefined Behavior: ",
-                    glow::DEBUG_TYPE_PERFORMANCE => "Performance: ",
-                    ty => unreachable!("unknown debug type {ty}"),
-                };
-                match sevr {
-                    glow::DEBUG_SEVERITY_NOTIFICATION => debug!(target: "opengl", "{ty}{msg}"),
-                    glow::DEBUG_SEVERITY_LOW => info!(target: "opengl", "{ty}{msg}"),
-                    glow::DEBUG_SEVERITY_MEDIUM => warn!(target: "opengl", "{ty}{msg}"),
-                    glow::DEBUG_SEVERITY_HIGH => error!(target: "opengl", "{ty}{msg}"),
-                    sevr => unreachable!("unknown debug severity {sevr}"),
-                };
-            });
-
-            gl.enable(glow::DEBUG_OUTPUT);
-        }
-    }
-
-    Ok(App {
-        gl,
-        gl_ctx,
-        gl_surface,
-        gl_display,
-        window,
-        events,
-    })
-}
-
-fn handle_close(event: Event<()>, control_flow: &mut ControlFlow) {
-    if let Event::WindowEvent { event, .. } = event {
-        match event {
-            WindowEvent::CloseRequested => control_flow.set_exit(),
-            WindowEvent::KeyboardInput {
-                input:
-                    KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::Escape),
-                        state: ElementState::Pressed,
-                        ..
-                    },
-                ..
-            } => {
-                info!("There is an Escape D:");
-                control_flow.set_exit();
-            }
-            _ => (),
-        }
-    }
 }

--- a/examples/render_wgpu.rs
+++ b/examples/render_wgpu.rs
@@ -52,7 +52,7 @@ pub async fn run(mut model: Model) {
         width: window.inner_size().width,
         height: window.inner_size().height,
         present_mode: wgpu::PresentMode::Fifo,
-        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+        alpha_mode: wgpu::CompositeAlphaMode::PreMultiplied,
         view_formats: Vec::new(),
     };
     surface.configure(&device, &config);

--- a/src/params.rs
+++ b/src/params.rs
@@ -6,7 +6,7 @@ use crate::math::interp::{
 use crate::math::matrix::Matrix2d;
 use crate::nodes::node::InoxNodeUuid;
 use crate::puppet::Puppet;
-use crate::render::{RenderCtxKind, NodeRenderCtxs, PartRenderCtx};
+use crate::render::{NodeRenderCtxs, PartRenderCtx, RenderCtxKind};
 
 /// Parameter binding to a node. This allows to animate a node based on the value of the parameter that owns it.
 #[derive(Debug, Clone)]
@@ -62,12 +62,7 @@ pub struct Param {
 }
 
 impl Param {
-    pub fn apply(
-        &self,
-        val: Vec2,
-        node_render_ctxs: &mut NodeRenderCtxs,
-        deform_buf: &mut [Vec2],
-    ) {
+    pub fn apply(&self, val: Vec2, node_render_ctxs: &mut NodeRenderCtxs, deform_buf: &mut [Vec2]) {
         let val = val.clamp(self.min, self.max);
         let val_normed = (val - self.min) / (self.max - self.min);
 

--- a/src/render/wgpu/buffers.rs
+++ b/src/render/wgpu/buffers.rs
@@ -1,14 +1,10 @@
 use std::collections::HashMap;
 
-use encase::ShaderType;
 use wgpu::{util::DeviceExt, Buffer, BufferDescriptor, BufferUsages, Device};
 
 use crate::{nodes::node::InoxNodeUuid, puppet::Puppet};
 
-use super::pipeline::CameraData;
-
 pub struct InoxBuffers {
-    pub camera_buffer: Buffer,
     pub uniform_buffer: Buffer,
     pub uniform_index_map: HashMap<InoxNodeUuid, usize>,
 
@@ -32,13 +28,6 @@ pub fn buffers_for_puppet(
     {
         uniform_index_map.insert(node.uuid, i);
     }
-
-    let camera_buffer = device.create_buffer(&BufferDescriptor {
-        label: Some("inox2d uniform buffer"),
-        size: CameraData::min_size().get(),
-        usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
-        mapped_at_creation: false,
-    });
 
     let uniform_buffer = device.create_buffer(&BufferDescriptor {
         label: Some("inox2d uniform buffer"),
@@ -72,7 +61,6 @@ pub fn buffers_for_puppet(
     });
 
     InoxBuffers {
-        camera_buffer,
         uniform_buffer,
         uniform_index_map,
 

--- a/src/render/wgpu/buffers.rs
+++ b/src/render/wgpu/buffers.rs
@@ -51,7 +51,7 @@ pub fn buffers_for_puppet(
     let deform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("deform buffer"),
         contents: bytemuck::cast_slice(&puppet.render_ctx.vertex_buffers.deforms),
-        usage: wgpu::BufferUsages::VERTEX,
+        usage: wgpu::BufferUsages::VERTEX | BufferUsages::COPY_DST,
     });
 
     let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -18,7 +18,6 @@ use tracing::warn;
 use wgpu::{util::DeviceExt, *};
 
 use self::node_bundle::{CompositeData, PartData};
-use self::pipeline::CameraData;
 use self::{
     buffers::buffers_for_puppet,
     node_bundle::{node_bundles_for_model, NodeBundle},
@@ -286,14 +285,6 @@ impl Renderer {
             label: Some("inox2d uniform bind group"),
             layout: &self.setup.uniform_layout,
             entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &self.buffers.camera_buffer,
-                        offset: 0,
-                        size: wgpu::BufferSize::new(CameraData::min_size().get()),
-                    }),
-                },
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -4,9 +4,7 @@ mod buffers;
 mod node_bundle;
 mod pipeline;
 
-use crate::nodes::node::InoxNodeUuid;
 use crate::nodes::node_data::InoxData;
-use crate::nodes::node_tree::InoxNodeTree;
 use crate::puppet::Puppet;
 use crate::render::RenderCtxKind;
 use crate::texture::decode_model_textures;
@@ -364,7 +362,7 @@ impl Renderer {
                     mult_color: Vec3::ONE,
                     screen_color: Vec3::ZERO,
                     emission_strength: 0.0,
-                    offset: node_absolute_translation(&puppet.nodes, uuid).truncate(),
+                    offset: puppet.render_ctx.node_render_ctxs[&uuid].trans.to_scale_rotation_translation().2.truncate(),
                 },
                 InoxData::Composite(_) => Uniform {
                     opacity: 1.0,
@@ -430,12 +428,4 @@ impl Renderer {
         }
         queue.submit(std::iter::once(encoder.finish()));
     }
-}
-
-fn node_absolute_translation<T>(nodes: &InoxNodeTree<T>, uuid: InoxNodeUuid) -> Vec3 {
-    nodes
-        .ancestors(uuid)
-        .filter_map(|n| nodes.arena.get(n))
-        .map(|n| n.get().trans_offset.translation)
-        .sum::<Vec3>()
 }

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -364,10 +364,7 @@ impl Renderer {
                     mult_color: Vec3::ONE,
                     screen_color: Vec3::ZERO,
                     emission_strength: 0.0,
-                    offset: puppet.render_ctx.node_render_ctxs[&uuid]
-                        .trans_offset
-                        .translation
-                        .truncate(),
+                    offset: node_absolute_translation(&puppet.nodes, uuid).truncate(),
                 },
                 InoxData::Composite(_) => Uniform {
                     opacity: 1.0,

--- a/src/render/wgpu/node_bundle.rs
+++ b/src/render/wgpu/node_bundle.rs
@@ -97,16 +97,14 @@ pub fn node_bundles_for_model(
     let uniform_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("inox2d uniform bind group"),
         layout: &setup.uniform_layout,
-        entries: &[
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &buffers.uniform_buffer,
-                    offset: 0,
-                    size: wgpu::BufferSize::new(Uniform::min_size().get()),
-                }),
-            },
-        ],
+        entries: &[wgpu::BindGroupEntry {
+            binding: 1,
+            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                buffer: &buffers.uniform_buffer,
+                offset: 0,
+                size: wgpu::BufferSize::new(Uniform::min_size().get()),
+            }),
+        }],
     });
 
     let mut out = Vec::new();

--- a/src/render/wgpu/node_bundle.rs
+++ b/src/render/wgpu/node_bundle.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{
     buffers::InoxBuffers,
-    pipeline::{CameraData, InoxPipeline, Uniform},
+    pipeline::{InoxPipeline, Uniform},
 };
 
 #[derive(Debug)]
@@ -98,14 +98,6 @@ pub fn node_bundles_for_model(
         label: Some("inox2d uniform bind group"),
         layout: &setup.uniform_layout,
         entries: &[
-            wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &buffers.camera_buffer,
-                    offset: 0,
-                    size: wgpu::BufferSize::new(CameraData::min_size().get()),
-                }),
-            },
             wgpu::BindGroupEntry {
                 binding: 1,
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {

--- a/src/render/wgpu/pipeline.rs
+++ b/src/render/wgpu/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use encase::ShaderType;
-use glam::{Vec2, Vec3};
+use glam::{Vec2, Vec3, Mat4};
 use wgpu::*;
 
 use crate::nodes::node_data::BlendMode;
@@ -330,4 +330,5 @@ pub struct Uniform {
     pub screen_color: Vec3,
     pub emission_strength: f32,
     pub offset: Vec2,
+    pub mvp: Mat4,
 }

--- a/src/render/wgpu/pipeline.rs
+++ b/src/render/wgpu/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use encase::ShaderType;
-use glam::{Mat4, Vec2, Vec3};
+use glam::{Vec2, Vec3};
 use wgpu::*;
 
 use crate::nodes::node_data::BlendMode;
@@ -211,16 +211,6 @@ impl InoxPipeline {
             label: Some("inox2d uniform bind group layout"),
             entries: &[
                 BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: ShaderStages::VERTEX,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: BufferSize::new(CameraData::min_size().get()),
-                    },
-                    count: None,
-                },
-                BindGroupLayoutEntry {
                     binding: 1,
                     visibility: ShaderStages::VERTEX_FRAGMENT,
                     ty: BindingType::Buffer {
@@ -331,11 +321,6 @@ impl InoxPipeline {
                 as usize,
         }
     }
-}
-
-#[derive(ShaderType, Debug, Clone, Copy, PartialEq)]
-pub struct CameraData {
-    pub mvp: Mat4,
 }
 
 #[derive(ShaderType, Debug, Clone, Copy, PartialEq)]

--- a/src/render/wgpu/pipeline.rs
+++ b/src/render/wgpu/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use encase::ShaderType;
-use glam::{Vec2, Vec3, Mat4};
+use glam::{Mat4, Vec2, Vec3};
 use wgpu::*;
 
 use crate::nodes::node_data::BlendMode;
@@ -209,18 +209,16 @@ impl InoxPipeline {
     pub fn create(device: &Device, texture_format: TextureFormat) -> Self {
         let uniform_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             label: Some("inox2d uniform bind group layout"),
-            entries: &[
-                BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: ShaderStages::VERTEX_FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: true,
-                        min_binding_size: BufferSize::new(Uniform::min_size().get()),
-                    },
-                    count: None,
+            entries: &[BindGroupLayoutEntry {
+                binding: 1,
+                visibility: ShaderStages::VERTEX_FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: BufferSize::new(Uniform::min_size().get()),
                 },
-            ],
+                count: None,
+            }],
         });
 
         let texture_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/src/render/wgpu/shaders/basic/anim.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/anim.vert.wgsl
@@ -3,19 +3,12 @@ struct VertexOutput {
     @location(0) texUVs: vec2<f32>,
 };
 
-struct Camera {
-    mvp: mat4x4<f32>,
-}
-
 struct Uniform {
     offset: vec2<f32>,
     splits: vec2<f32>,
     animation: f32,
     frame: f32,
 };
-
-@group(0) @binding(0)
-var<uniform> camera: Camera;
 
 @group(0) @binding(1)
 var<uniform> unif: Uniform;

--- a/src/render/wgpu/shaders/basic/basic.frag.wgsl
+++ b/src/render/wgpu/shaders/basic/basic.frag.wgsl
@@ -15,6 +15,7 @@ struct Uniform {
     screenColor: vec3<f32>,
     emissionStrength: f32,
     offset: vec2<f32>,
+    mvp: mat4x4<f32>,
 };
 
 @group(0) @binding(1)

--- a/src/render/wgpu/shaders/basic/basic.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/basic.vert.wgsl
@@ -24,7 +24,7 @@ fn vs_main(
 
     var temp = (verts + deform + unif.offset) / 4096.0;
 
-    out.position = vec4(temp , 0.0, 1.0);
+    out.position = vec4(temp, 0.0, 1.0);
     out.position.y = -out.position.y;
     out.texUVs = uvs;
     return out;

--- a/src/render/wgpu/shaders/basic/basic.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/basic.vert.wgsl
@@ -9,6 +9,7 @@ struct Uniform {
     screenColor: vec3<f32>,
     emissionStrength: f32,
     offset: vec2<f32>,
+    mvp: mat4x4<f32>,
 };
 
 @group(0) @binding(1)
@@ -22,10 +23,8 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
 
-    var temp = (verts + deform + unif.offset) / 4096.0;
+    out.position = unif.mvp * vec4(verts + deform - unif.offset, 0.0, 1.0);
 
-    out.position = vec4(temp, 0.0, 1.0);
-    out.position.y = -out.position.y;
     out.texUVs = uvs;
     return out;
 }

--- a/src/render/wgpu/shaders/basic/basic.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/basic.vert.wgsl
@@ -3,10 +3,6 @@ struct VertexOutput {
     @location(0) texUVs: vec2<f32>,
 };
 
-struct Camera {
-    mvp: mat4x4<f32>,
-}
-
 struct Uniform {
     opacity: f32,
     multColor: vec3<f32>,
@@ -14,9 +10,6 @@ struct Uniform {
     emissionStrength: f32,
     offset: vec2<f32>,
 };
-
-@group(0) @binding(0)
-var<uniform> camera: Camera;
 
 @group(0) @binding(1)
 var<uniform> unif: Uniform;

--- a/src/render/wgpu/shaders/basic/mask.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/mask.vert.wgsl
@@ -9,6 +9,7 @@ struct Uniform {
     screenColor: vec3<f32>,
     emissionStrength: f32,
     offset: vec2<f32>,
+    mvp: mat4x4<f32>,
 };
 
 @group(0) @binding(1)
@@ -21,11 +22,7 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
 
-    var temp = (verts + unif.offset) / 4096.0;
-
-    out.position = vec4(temp, 0.0, 1.0);
-    out.position.y = -out.position.y;
-
+    out.position = unif.mvp * vec4(verts - unif.offset, 0.0, 1.0);
     out.texUVs = uvs;
     return out;
 }

--- a/src/render/wgpu/shaders/basic/mask.vert.wgsl
+++ b/src/render/wgpu/shaders/basic/mask.vert.wgsl
@@ -3,10 +3,6 @@ struct VertexOutput {
     @location(0) texUVs: vec2<f32>,
 };
 
-struct Camera {
-    mvp: mat4x4<f32>,
-}
-
 struct Uniform {
     opacity: f32,
     multColor: vec3<f32>,
@@ -14,9 +10,6 @@ struct Uniform {
     emissionStrength: f32,
     offset: vec2<f32>,
 };
-
-@group(0) @binding(0)
-var<uniform> camera: Camera;
 
 @group(0) @binding(1)
 var<uniform> unif: Uniform;


### PR DESCRIPTION
- closes #27

This is a refactor of the WGPU renderer, so that it uses our new renderer-agnostic API.
It also introduces a proper camera and viewport into the renderer, and makes sure texture views resize to this viewport.

- [x] Implement simple camera controls to the WGPU renderer example, just like in the OpenGL renderer example