### PR TITLE
`InoxRenderer` trait.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup aarch64
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'
         run: |
+          sudo apt update
           sudo apt install gcc-aarch64-linux-gnu
           echo "[target.aarch64-unknown-linux-gnu]" >> ~/.cargo/config
           echo "linker = \"aarch64-linux-gnu-gcc\"" >> ~/.cargo/config

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
     "no-inline-html": false,
     "first-line-heading": false
   },
-  "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+  // "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
 }

--- a/examples/render-opengl/src/main.rs
+++ b/examples/render-opengl/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut renderer = OpenglRenderer::new(gl)?;
     renderer.prepare(&model)?;
-    renderer.resize(window_size.width, window_size.height)?;
+    renderer.resize(window_size.width, window_size.height);
     renderer.camera.scale = Vec2::splat(0.15);
     info!("Inox2D renderer initialized");
 

--- a/examples/render-webgl/src/main.rs
+++ b/examples/render-webgl/src/main.rs
@@ -97,7 +97,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Creating buffers and uploading model textures");
     renderer.prepare(&model)?;
-    renderer.resize(window_size.width, window_size.height)?;
+    renderer.resize(window_size.width, window_size.height);
     renderer.camera.scale = Vec2::splat(0.15);
     info!("Inox2D renderer initialized");
 

--- a/examples/render-webgl/src/scene.rs
+++ b/examples/render-webgl/src/scene.rs
@@ -2,7 +2,6 @@
 
 use glam::{vec2, Vec2};
 use inox2d::math::camera::Camera;
-use tracing::info;
 use web_time::Instant;
 use winit::event::{ElementState, MouseScrollDelta, WindowEvent};
 use winit::window::Window;

--- a/inox2d-opengl/src/gl_buffer.rs
+++ b/inox2d-opengl/src/gl_buffer.rs
@@ -1,4 +1,4 @@
-use glow::HasContext;
+use glow::{HasContext, NativeVertexArray};
 
 use inox2d::render::RenderCtx;
 
@@ -31,6 +31,7 @@ pub trait RenderCtxOpenglExt {
     unsafe fn setup_gl_buffers(
         &self,
         gl: &glow::Context,
+        vao: NativeVertexArray,
     ) -> Result<glow::VertexArray, OpenglRendererError>;
     unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context);
 }
@@ -44,14 +45,12 @@ impl RenderCtxOpenglExt for RenderCtx {
     ///
     /// # Safety
     ///
-    /// Only call this function once (probably).
+    /// Only call this function once when loading a new puppet.
     unsafe fn setup_gl_buffers(
         &self,
         gl: &glow::Context,
+        vao: NativeVertexArray,
     ) -> Result<glow::VertexArray, OpenglRendererError> {
-        let vao = gl
-            .create_vertex_array()
-            .map_err(OpenglRendererError::Opengl)?;
         gl.bind_vertex_array(Some(vao));
 
         upload_array_to_gl(

--- a/inox2d-opengl/src/gl_buffer.rs
+++ b/inox2d-opengl/src/gl_buffer.rs
@@ -1,4 +1,4 @@
-use glow::{HasContext, NativeVertexArray};
+use glow::HasContext;
 
 use inox2d::render::RenderCtx;
 
@@ -31,7 +31,7 @@ pub trait RenderCtxOpenglExt {
     unsafe fn setup_gl_buffers(
         &self,
         gl: &glow::Context,
-        vao: NativeVertexArray,
+        vao: glow::VertexArray,
     ) -> Result<glow::VertexArray, OpenglRendererError>;
     unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context);
 }
@@ -49,7 +49,7 @@ impl RenderCtxOpenglExt for RenderCtx {
     unsafe fn setup_gl_buffers(
         &self,
         gl: &glow::Context,
-        vao: NativeVertexArray,
+        vao: glow::VertexArray,
     ) -> Result<glow::VertexArray, OpenglRendererError> {
         gl.bind_vertex_array(Some(vao));
 

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -379,7 +379,7 @@ impl InoxRenderer for OpenglRenderer {
         }
     }
 
-    fn resize(&mut self, w: u32, h: u32) -> Result<(), Self::Error> {
+    fn resize(&mut self, w: u32, h: u32) {
         self.viewport = uvec2(w, h);
 
         let gl = &self.gl;
@@ -407,15 +407,12 @@ impl InoxRenderer for OpenglRenderer {
             self.attach_framebuffer_textures();
         }
         self.update_camera();
-
-        Ok(())
     }
 
-    fn clear(&self) -> Result<(), Self::Error> {
+    fn clear(&self) {
         unsafe {
             self.gl.clear(glow::COLOR_BUFFER_BIT);
         }
-        Ok(())
     }
 
     /*
@@ -425,11 +422,11 @@ impl InoxRenderer for OpenglRenderer {
         draw_scene -> actually makes things appear on a surface
     */
 
-    fn on_begin_scene(&self) -> Result<(), Self::Error> {
+    fn on_begin_scene(&self) {
         todo!()
     }
 
-    fn render(&self, puppet: &Puppet) -> Result<(), Self::Error> {
+    fn render(&self, puppet: &Puppet) {
         let gl = &self.gl;
         unsafe {
             puppet.render_ctx.upload_deforms_to_gl(gl);
@@ -440,20 +437,18 @@ impl InoxRenderer for OpenglRenderer {
         let camera = self
             .camera
             .matrix(Vec2::new(self.viewport.x as f32, self.viewport.y as f32));
-        self.draw_drawables(&camera, puppet)?;
-
-        Ok(())
+        self.draw(&camera, puppet);
     }
 
-    fn on_end_scene(&self) -> Result<(), Self::Error> {
+    fn on_end_scene(&self) {
         todo!()
     }
 
-    fn draw_scene(&self) -> Result<(), Self::Error> {
+    fn draw_scene(&self) {
         todo!()
     }
 
-    fn on_begin_mask(&self, has_mask: bool) -> Result<(), Self::Error> {
+    fn on_begin_mask(&self, has_mask: bool) {
         let gl = &self.gl;
         unsafe {
             gl.enable(glow::STENCIL_TEST);
@@ -464,18 +459,16 @@ impl InoxRenderer for OpenglRenderer {
             gl.stencil_op(glow::KEEP, glow::KEEP, glow::REPLACE);
             gl.stencil_mask(0xff);
         }
-        Ok(())
     }
 
-    fn set_mask_mode(&self, dodge: bool) -> Result<(), Self::Error> {
+    fn set_mask_mode(&self, dodge: bool) {
         let gl = &self.gl;
         unsafe {
             gl.stencil_func(glow::ALWAYS, !dodge as i32, 0xff);
         }
-        Ok(())
     }
 
-    fn on_begin_masked_content(&self) -> Result<(), Self::Error> {
+    fn on_begin_masked_content(&self) {
         let gl = &self.gl;
         unsafe {
             gl.stencil_func(glow::EQUAL, 1, 0xff);
@@ -483,21 +476,18 @@ impl InoxRenderer for OpenglRenderer {
 
             gl.color_mask(true, true, true, true);
         }
-        Ok(())
     }
 
-    fn on_end_mask(&self) -> Result<(), Self::Error> {
+    fn on_end_mask(&self) {
         let gl = &self.gl;
         unsafe {
             gl.stencil_mask(0xff);
             gl.stencil_func(glow::ALWAYS, 1, 0xff);
             gl.disable(glow::STENCIL_TEST);
         }
-
-        Ok(())
     }
 
-    fn draw_mesh_self(&self, as_mask: bool, camera: &Mat4) -> Result<(), Self::Error> {
+    fn draw_mesh_self(&self, as_mask: bool, camera: &Mat4) {
         /*
         maskShader.use();
         maskShader.setUniform(offset, data.origin);
@@ -524,7 +514,7 @@ impl InoxRenderer for OpenglRenderer {
         node_render_ctx: &NodeRenderCtx,
         part: &Part,
         part_render_ctx: &PartRenderCtx,
-    ) -> Result<(), Self::Error> {
+    ) {
         let gl = &self.gl;
 
         self.bind_part_textures(part);
@@ -566,11 +556,9 @@ impl InoxRenderer for OpenglRenderer {
                 part_render_ctx.index_offset as i32 * mem::size_of::<u16>() as i32,
             );
         }
-
-        Ok(())
     }
 
-    fn begin_composite_content(&self) -> Result<(), Self::Error> {
+    fn begin_composite_content(&self) {
         self.clear_texture_cache();
 
         let gl = &self.gl;
@@ -589,15 +577,9 @@ impl InoxRenderer for OpenglRenderer {
             gl.active_texture(glow::TEXTURE0);
             gl.blend_func(glow::ONE, glow::ONE_MINUS_SRC_ALPHA);
         }
-
-        Ok(())
     }
 
-    fn finish_composite_content(
-        &self,
-        as_mask: bool,
-        composite: &Composite,
-    ) -> Result<(), Self::Error> {
+    fn finish_composite_content(&self, as_mask: bool, composite: &Composite) {
         let gl = &self.gl;
 
         self.clear_texture_cache();
@@ -642,7 +624,5 @@ impl InoxRenderer for OpenglRenderer {
         unsafe {
             gl.draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_SHORT, 0);
         }
-
-        Ok(())
     }
 }

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -3,21 +3,21 @@ mod shader;
 mod shaders;
 pub mod texture;
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::mem;
 use std::ops::Deref;
 
 use gl_buffer::RenderCtxOpenglExt;
-use glam::{uvec2, UVec2, Vec3};
+use glam::{uvec2, Mat4, UVec2, Vec2, Vec3};
 use glow::HasContext;
 use tracing::{debug, error};
 
 use inox2d::math::camera::Camera;
-use inox2d::model::ModelTexture;
+use inox2d::model::{Model, ModelTexture};
 use inox2d::nodes::node::InoxNodeUuid;
-use inox2d::nodes::node_data::{BlendMode, Composite, InoxData, Mask, MaskMode, Part};
+use inox2d::nodes::node_data::{BlendMode, Composite, Part};
 use inox2d::puppet::Puppet;
-use inox2d::render::{NodeRenderCtx, PartRenderCtx, RenderCtxKind};
+use inox2d::render::{InoxRenderer, NodeRenderCtx, PartRenderCtx};
 use inox2d::texture::decode_model_textures;
 
 use self::shader::ShaderCompileError;
@@ -113,7 +113,6 @@ pub struct OpenglRenderer {
     pub camera: Camera,
     pub viewport: UVec2,
     cache: RefCell<GlCache>,
-    is_compositing: Cell<bool>,
 
     vao: glow::VertexArray,
 
@@ -132,73 +131,7 @@ pub struct OpenglRenderer {
 }
 
 impl OpenglRenderer {
-    pub fn new(
-        gl: glow::Context,
-        viewport: UVec2,
-        puppet: &Puppet,
-    ) -> Result<Self, OpenglRendererError> {
-        let vao = unsafe { puppet.render_ctx.setup_gl_buffers(&gl)? };
-
-        // Initialize framebuffers
-        let composite_framebuffer;
-        let cf_albedo;
-        let cf_emissive;
-        let cf_bump;
-        let cf_stencil;
-        unsafe {
-            cf_albedo = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
-            cf_emissive = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
-            cf_bump = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
-            cf_stencil = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
-
-            composite_framebuffer = gl
-                .create_framebuffer()
-                .map_err(OpenglRendererError::Opengl)?;
-        }
-
-        // Shaders
-        let part_shader = PartShader::new(&gl)?;
-        let part_mask_shader = PartMaskShader::new(&gl)?;
-        let composite_shader = CompositeShader::new(&gl)?;
-        let composite_mask_shader = CompositeMaskShader::new(&gl)?;
-
-        let support_debug_extension = gl.supported_extensions().contains("GL_KHR_debug");
-
-        let mut renderer = Self {
-            gl,
-            support_debug_extension,
-            camera: Camera::default(),
-            viewport,
-            cache: RefCell::new(GlCache::default()),
-            is_compositing: Cell::new(false),
-
-            vao,
-
-            composite_framebuffer,
-            cf_albedo,
-            cf_emissive,
-            cf_bump,
-            cf_stencil,
-
-            part_shader,
-            part_mask_shader,
-            composite_shader,
-            composite_mask_shader,
-
-            textures: Vec::new(),
-        };
-
-        // Set emission strength once (it doesn't change anywhere else)
-        renderer.bind_shader(&renderer.part_shader);
-        renderer.part_shader.set_emission_strength(&renderer.gl, 1.);
-
-        renderer.resize(viewport.x, viewport.y);
-        unsafe { renderer.attach_framebuffer_textures() };
-
-        Ok(renderer)
-    }
-
-    pub fn upload_model_textures(
+    fn upload_model_textures(
         &mut self,
         model_textures: &[ModelTexture],
     ) -> Result<(), TextureError> {
@@ -213,41 +146,6 @@ impl OpenglRenderer {
         }
 
         Ok(())
-    }
-
-    pub fn resize(&mut self, w: u32, h: u32) {
-        self.viewport = uvec2(w, h);
-
-        let gl = &self.gl;
-        unsafe {
-            gl.viewport(0, 0, w as i32, h as i32);
-
-            // Reupload composite framebuffer textures
-            texture::upload_empty(gl, self.cf_albedo, w, h, glow::UNSIGNED_BYTE);
-            texture::upload_empty(gl, self.cf_emissive, w, h, glow::FLOAT);
-            texture::upload_empty(gl, self.cf_bump, w, h, glow::UNSIGNED_BYTE);
-
-            gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_stencil));
-            gl.tex_image_2d(
-                glow::TEXTURE_2D,
-                0,
-                glow::DEPTH24_STENCIL8 as i32,
-                w as i32,
-                h as i32,
-                0,
-                glow::DEPTH_STENCIL,
-                glow::UNSIGNED_INT_24_8,
-                None,
-            );
-
-            self.attach_framebuffer_textures();
-        }
-
-        self.update_camera();
-    }
-
-    pub fn clear(&self) {
-        unsafe { self.gl.clear(glow::COLOR_BUFFER_BIT) };
     }
 
     /// Pushes an OpenGL debug group.
@@ -399,10 +297,142 @@ impl OpenglRenderer {
 
         gl.bind_framebuffer(glow::FRAMEBUFFER, None);
     }
+}
 
-    pub fn render(&self, puppet: &Puppet) {
+impl InoxRenderer for OpenglRenderer {
+    type Context = glow::Context;
+    type Error = OpenglRendererError;
+
+    fn new(gl: Self::Context) -> Result<Self, Self::Error> {
+        let vao = unsafe {
+            gl.create_vertex_array()
+                .map_err(OpenglRendererError::Opengl)?
+        };
+
+        // Initialize framebuffers
+        let composite_framebuffer;
+        let cf_albedo;
+        let cf_emissive;
+        let cf_bump;
+        let cf_stencil;
+        unsafe {
+            cf_albedo = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
+            cf_emissive = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
+            cf_bump = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
+            cf_stencil = gl.create_texture().map_err(OpenglRendererError::Opengl)?;
+
+            composite_framebuffer = gl
+                .create_framebuffer()
+                .map_err(OpenglRendererError::Opengl)?;
+        }
+
+        // Shaders
+        let part_shader = PartShader::new(&gl)?;
+        let part_mask_shader = PartMaskShader::new(&gl)?;
+        let composite_shader = CompositeShader::new(&gl)?;
+        let composite_mask_shader = CompositeMaskShader::new(&gl)?;
+
+        let support_debug_extension = gl.supported_extensions().contains("GL_KHR_debug");
+
+        let renderer = Self {
+            gl,
+            support_debug_extension,
+            camera: Camera::default(),
+            viewport: UVec2::default(),
+            cache: RefCell::new(GlCache::default()),
+
+            vao,
+
+            composite_framebuffer,
+            cf_albedo,
+            cf_emissive,
+            cf_bump,
+            cf_stencil,
+
+            part_shader,
+            part_mask_shader,
+            composite_shader,
+            composite_mask_shader,
+
+            textures: Vec::new(),
+        };
+
+        // Set emission strength once (it doesn't change anywhere else)
+        renderer.bind_shader(&renderer.part_shader);
+        renderer.part_shader.set_emission_strength(&renderer.gl, 1.);
+
+        unsafe { renderer.attach_framebuffer_textures() };
+
+        Ok(renderer)
+    }
+
+    fn prepare(&mut self, model: &Model) -> Result<(), Self::Error> {
+        unsafe {
+            model
+                .puppet
+                .render_ctx
+                .setup_gl_buffers(&self.gl, self.vao)?
+        };
+
+        match self.upload_model_textures(&model.textures) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(OpenglRendererError::Opengl(
+                "Texture Upload Error.".to_string(),
+            )),
+        }
+    }
+
+    fn resize(&mut self, w: u32, h: u32) -> Result<(), Self::Error> {
+        self.viewport = uvec2(w, h);
+
+        let gl = &self.gl;
+        unsafe {
+            gl.viewport(0, 0, w as i32, h as i32);
+
+            // Reupload composite framebuffer textures
+            texture::upload_empty(gl, self.cf_albedo, w, h, glow::UNSIGNED_BYTE);
+            texture::upload_empty(gl, self.cf_emissive, w, h, glow::FLOAT);
+            texture::upload_empty(gl, self.cf_bump, w, h, glow::UNSIGNED_BYTE);
+
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_stencil));
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::DEPTH24_STENCIL8 as i32,
+                w as i32,
+                h as i32,
+                0,
+                glow::DEPTH_STENCIL,
+                glow::UNSIGNED_INT_24_8,
+                None,
+            );
+
+            self.attach_framebuffer_textures();
+        }
         self.update_camera();
 
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<(), Self::Error> {
+        unsafe {
+            self.gl.clear(glow::COLOR_BUFFER_BIT);
+        }
+        Ok(())
+    }
+
+    /*
+        These functions should be reworked together:
+        setup_gl_buffers -> should set up in a way so that the draw functions draws into a texture
+        on_begin/end_scene -> prepares and ends drawing to texture. also post-processing
+        draw_scene -> actually makes things appear on a surface
+    */
+
+    fn on_begin_scene(&self) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn render(&self, puppet: &Puppet) -> Result<(), Self::Error> {
         let gl = &self.gl;
         unsafe {
             puppet.render_ctx.upload_deforms_to_gl(gl);
@@ -410,113 +440,105 @@ impl OpenglRenderer {
             gl.disable(glow::DEPTH_TEST);
         }
 
-        for &uuid in &puppet.render_ctx.nodes_zsorted {
-            self.draw_node(puppet, uuid, false, false);
-        }
+        let camera = self
+            .camera
+            .matrix(Vec2::new(self.viewport.x as f32, self.viewport.y as f32));
+        self.draw_drawables(&camera, puppet)?;
+
+        Ok(())
     }
 
-    fn draw_node(
-        &self,
-        puppet: &Puppet,
-        uuid: InoxNodeUuid,
-        is_composite_child: bool,
-        is_mask: bool,
-    ) {
-        let node = puppet.nodes.get_node(uuid).unwrap();
-        let node_render_ctx = &puppet.render_ctx.node_render_ctxs[&uuid];
-
-        match (&node.data, &node_render_ctx.kind) {
-            (InoxData::Part(ref part), RenderCtxKind::Part(ref part_render_ctx)) => {
-                self.draw_part(
-                    puppet,
-                    part,
-                    node_render_ctx,
-                    part_render_ctx,
-                    is_composite_child,
-                    is_mask,
-                    &node.name,
-                );
-            }
-
-            (InoxData::Composite(ref composite), RenderCtxKind::Composite(ref children)) => {
-                self.draw_composite(puppet, composite, children, &node.name);
-            }
-
-            _ => (),
-        }
+    fn on_end_scene(&self) -> Result<(), Self::Error> {
+        todo!()
     }
 
-    ////////////////////////
-    //// Part rendering ////
-    ////////////////////////
+    fn draw_scene(&self) -> Result<(), Self::Error> {
+        todo!()
+    }
 
-    fn draw_part_mask(&self, puppet: &Puppet, mask: &Mask, is_composite_child: bool) {
+    fn on_begin_mask(&self, has_mask: bool) -> Result<(), Self::Error> {
         let gl = &self.gl;
-
-        // begin draw mask
         unsafe {
-            // Enable writing to stencil buffer and disable writing to color buffer
+            gl.enable(glow::STENCIL_TEST);
+            gl.clear_stencil(!has_mask as i32);
+            gl.clear(glow::STENCIL_BUFFER_BIT);
+
             gl.color_mask(false, false, false, false);
             gl.stencil_op(glow::KEEP, glow::KEEP, glow::REPLACE);
-            gl.stencil_func(glow::ALWAYS, (mask.mode == MaskMode::Mask) as i32, 0xff);
             gl.stencil_mask(0xff);
         }
-
-        // draw mask
-        self.draw_node(puppet, mask.source, is_composite_child, true);
-
-        // end draw mask
-        unsafe {
-            gl.color_mask(true, true, true, true);
-        }
+        Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn draw_part(
-        &self,
-        puppet: &Puppet,
-        part: &Part,
-        node_render_ctx: &NodeRenderCtx,
-        part_render_ctx: &PartRenderCtx,
-        is_composite_child: bool,
-        is_mask: bool,
-        debug_label: &str,
-    ) {
-        self.push_debug_group(debug_label);
-
+    fn set_mask_mode(&self, dodge: bool) -> Result<(), Self::Error> {
         let gl = &self.gl;
-        let masks = &part.draw_state.masks;
+        unsafe {
+            gl.stencil_func(glow::ALWAYS, !dodge as i32, 0xff);
+        }
+        Ok(())
+    }
 
-        if !masks.is_empty() {
-            self.push_debug_group("Masks");
+    fn on_begin_masked_content(&self) -> Result<(), Self::Error> {
+        let gl = &self.gl;
+        unsafe {
+            gl.stencil_func(glow::EQUAL, 1, 0xff);
+            gl.stencil_mask(0x00);
 
-            // begin mask
-            unsafe {
-                // Enable and clear the stencil buffer so we can write our mask to it
-                gl.enable(glow::STENCIL_TEST);
-                gl.clear_stencil(!part.draw_state.has_masks() as i32);
-                gl.clear(glow::STENCIL_BUFFER_BIT);
-            }
+            gl.color_mask(true, true, true, true);
+        }
+        Ok(())
+    }
 
-            for mask in &part.draw_state.masks {
-                self.draw_part_mask(puppet, mask, is_composite_child);
-            }
-
-            self.pop_debug_group();
-
-            // begin mask content
-            unsafe {
-                gl.stencil_func(glow::EQUAL, 1, 0xff);
-                gl.stencil_mask(0x00);
-            }
+    fn on_end_mask(&self) -> Result<(), Self::Error> {
+        let gl = &self.gl;
+        unsafe {
+            gl.stencil_mask(0xff);
+            gl.stencil_func(glow::ALWAYS, 1, 0xff);
+            gl.disable(glow::STENCIL_TEST);
         }
 
-        let mvp = self.camera.matrix(self.viewport.as_vec2()) * node_render_ctx.trans;
+        Ok(())
+    }
+
+    fn draw_mesh_self(&self, as_mask: bool, camera: &Mat4) -> Result<(), Self::Error> {
+        /*
+        maskShader.use();
+        maskShader.setUniform(offset, data.origin);
+        maskShader.setUniform(mvp, inGetCamera().matrix * transform.matrix());
+
+        // Enable points array
+        glEnableVertexAttribArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, vbo);
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, null);
+
+        // Bind index buffer
+        this.bindIndex();
+
+        // Disable the vertex attribs after use
+        glDisableVertexAttribArray(0);
+        */
+        todo!()
+    }
+
+    fn draw_part_self(
+        &self,
+        as_mask: bool,
+        camera: &Mat4,
+        node_render_ctx: &NodeRenderCtx,
+        part: &Part,
+        part_render_ctx: &PartRenderCtx,
+    ) -> Result<(), Self::Error> {
+        let gl = &self.gl;
 
         self.bind_part_textures(part);
         self.set_blend_mode(part.draw_state.blend_mode);
 
-        if is_mask {
+        let part_shader = &self.part_shader;
+        self.bind_shader(part_shader);
+        // vert uniforms
+        let mvp = *camera * node_render_ctx.trans;
+
+        if as_mask {
             let part_mask_shader = &self.part_mask_shader;
             self.bind_shader(part_mask_shader);
 
@@ -548,31 +570,10 @@ impl OpenglRenderer {
             );
         }
 
-        if !masks.is_empty() {
-            // end mask
-            unsafe {
-                // We're done stencil testing, disable it again so that we don't accidentally mask more stuff out
-                gl.stencil_mask(0xff);
-                gl.stencil_func(glow::ALWAYS, 1, 0xff);
-                gl.disable(glow::STENCIL_TEST);
-            }
-        }
-
-        self.pop_debug_group();
+        Ok(())
     }
 
-    /////////////////////////////
-    //// Composite rendering ////
-    /////////////////////////////
-
-    /// Begin a composition step
-    fn begin_composite(&self) {
-        if self.is_compositing.get() {
-            // We don't allow recursive compositing
-            return;
-        }
-        self.is_compositing.set(true);
-
+    fn begin_composite(&self) -> Result<(), Self::Error> {
         self.clear_texture_cache();
 
         let gl = &self.gl;
@@ -591,73 +592,75 @@ impl OpenglRenderer {
             gl.active_texture(glow::TEXTURE0);
             gl.blend_func(glow::ONE, glow::ONE_MINUS_SRC_ALPHA);
         }
+
+        Ok(())
     }
 
-    /// End a composition step, re-binding the internal framebuffer
-    fn end_composite(&self) {
-        if !self.is_compositing.get() {
-            // We don't allow recursive compositing
-            return;
-        }
-        self.is_compositing.set(false);
-
+    fn end_composite(&self) -> Result<(), Self::Error> {
         self.clear_texture_cache();
 
         let gl = &self.gl;
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         }
+
+        Ok(())
     }
 
     fn draw_composite(
         &self,
-        puppet: &Puppet,
+        as_mask: bool,
+        camera: &Mat4,
         composite: &Composite,
+        puppet: &Puppet,
         children: &[InoxNodeUuid],
-        debug_label: &str,
-    ) {
+    ) -> Result<(), Self::Error> {
         if children.is_empty() {
             // Optimization: Nothing to be drawn, skip context switching
-            return;
+            return Ok(());
         }
 
-        self.push_debug_group(debug_label);
-
-        self.begin_composite();
-        for uuid in children {
-            // debug_assert!(*uuid != node.uuid, "A composite lists itself as its child.");
-
-            self.draw_node(puppet, *uuid, true, false);
-        }
-        self.end_composite();
+        self.draw_composite_self(as_mask, camera, puppet, children)?;
 
         let gl = &self.gl;
-        unsafe {
-            gl.bind_vertex_array(Some(self.vao));
+        let comp = &composite.draw_state;
+        if as_mask {
+            /*
+            cShaderMask.use();
+            cShaderMask.setUniform(mopacity, opacity);
+            cShaderMask.setUniform(mthreshold, threshold);
+            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+            */
+            todo!()
+        } else {
+            unsafe {
+                gl.bind_vertex_array(Some(self.vao));
 
-            gl.active_texture(glow::TEXTURE0);
-            gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_albedo));
-            gl.active_texture(glow::TEXTURE1);
-            gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_emissive));
-            gl.active_texture(glow::TEXTURE2);
-            gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_bump));
+                gl.active_texture(glow::TEXTURE0);
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_albedo));
+                gl.active_texture(glow::TEXTURE1);
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_emissive));
+                gl.active_texture(glow::TEXTURE2);
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_bump));
+            }
+
+            self.set_blend_mode(comp.blend_mode);
+
+            let opacity = comp.opacity.clamp(0.0, 1.0);
+            let tint = comp.tint.clamp(Vec3::ZERO, Vec3::ONE);
+            let screen_tint = comp.screen_tint.clamp(Vec3::ZERO, Vec3::ONE);
+
+            let composite_shader = &self.composite_shader;
+            self.bind_shader(composite_shader);
+            composite_shader.set_opacity(gl, opacity);
+            composite_shader.set_mult_color(gl, tint);
+            composite_shader.set_screen_color(gl, screen_tint);
         }
 
-        let comp = &composite.draw_state;
-        self.set_blend_mode(comp.blend_mode);
-
-        let opacity = comp.opacity.clamp(0.0, 1.0);
-        let tint = comp.tint.clamp(Vec3::ZERO, Vec3::ONE);
-        let screen_tint = comp.screen_tint.clamp(Vec3::ZERO, Vec3::ONE);
-
-        self.bind_shader(&self.composite_shader);
-        self.composite_shader.set_opacity(gl, opacity);
-        self.composite_shader.set_mult_color(gl, tint);
-        self.composite_shader.set_screen_color(gl, screen_tint);
         unsafe {
             gl.draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_SHORT, 0);
         }
 
-        self.pop_debug_group();
+        Ok(())
     }
 }

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -17,7 +17,7 @@ use inox2d::model::{Model, ModelTexture};
 use inox2d::nodes::node::InoxNodeUuid;
 use inox2d::nodes::node_data::{BlendMode, Composite, Part};
 use inox2d::puppet::Puppet;
-use inox2d::render::{InoxRenderer, NodeRenderCtx, PartRenderCtx};
+use inox2d::render::{InoxRenderer, InoxRendererCommon, NodeRenderCtx, PartRenderCtx};
 use inox2d::texture::decode_model_textures;
 
 use self::shader::ShaderCompileError;

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -361,8 +361,6 @@ impl InoxRenderer for OpenglRenderer {
         renderer.bind_shader(&renderer.part_shader);
         renderer.part_shader.set_emission_strength(&renderer.gl, 1.);
 
-        unsafe { renderer.attach_framebuffer_textures() };
-
         Ok(renderer)
     }
 

--- a/inox2d-wgpu/src/node_bundle.rs
+++ b/inox2d-wgpu/src/node_bundle.rs
@@ -145,9 +145,6 @@ pub fn node_bundles_for_model(
             let mut bundles = Vec::new();
 
             for child_id in puppet.nodes.zsorted_children(uuid) {
-                if child_id == uuid {
-                    continue;
-                }
                 let child = puppet.nodes.get_node(child_id).unwrap();
 
                 if let InoxData::Part(part) = &child.data {

--- a/inox2d/src/formats/serialize.rs
+++ b/inox2d/src/formats/serialize.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use glam::{vec2, Vec2};
 use indextree::Arena;
@@ -415,7 +415,7 @@ fn deserialize_nodes<T>(
     deserialize_node_custom: &impl Fn(&str, &JsonObject) -> InoxParseResult<T>,
 ) -> InoxParseResult<InoxNodeTree<T>> {
     let mut arena = Arena::new();
-    let mut uuids = BTreeMap::new();
+    let mut uuids = HashMap::new();
 
     let root_node = deserialize_node_ext(obj, deserialize_node_custom)?;
     let root_uuid = root_node.uuid;

--- a/inox2d/src/nodes/node_tree.rs
+++ b/inox2d/src/nodes/node_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Display;
 
 use indextree::{Arena, NodeId};
@@ -9,7 +9,7 @@ use super::node::{InoxNode, InoxNodeUuid};
 pub struct InoxNodeTree<T = ()> {
     pub root: indextree::NodeId,
     pub arena: Arena<InoxNode<T>>,
-    pub uuids: BTreeMap<InoxNodeUuid, indextree::NodeId>,
+    pub uuids: HashMap<InoxNodeUuid, indextree::NodeId>,
 }
 
 impl<T> InoxNodeTree<T> {
@@ -81,16 +81,22 @@ impl<T> InoxNodeTree<T> {
         sort_uuids_by_zsort(uuid_zsorts)
     }
 
+    /// all nodes, zsorted, with composite children excluded
     pub fn zsorted_root(&self) -> Vec<InoxNodeUuid> {
         let root = self.arena.get(self.root).unwrap().get();
         self.sort_by_zsort(root, true)
     }
 
+    /// all children, grandchildren..., zsorted, with parent excluded
     pub fn zsorted_children(&self, id: InoxNodeUuid) -> Vec<InoxNodeUuid> {
         let node = self.arena.get(self.uuids[&id]).unwrap().get();
         self.sort_by_zsort(node, false)
+            .into_iter()
+            .filter(|uuid| *uuid != node.uuid)
+            .collect::<Vec<_>>()
     }
 
+    /// all nodes
     pub fn all_node_ids(&self) -> Vec<InoxNodeUuid> {
         self.arena.iter().map(|n| n.get().uuid).collect()
     }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -56,7 +56,7 @@ impl Default for VertexBuffers {
 }
 
 impl VertexBuffers {
-    /// adds the mesh's vertices and UVs to the buffers and returns its index offset.
+    /// Adds the mesh's vertices and UVs to the buffers and returns its index and vertex offset.
     pub fn push(&mut self, mesh: &Mesh) -> (u16, u16) {
         let index_offset = self.indices.len() as u16;
         let vert_offset = self.verts.len() as u16;
@@ -99,9 +99,9 @@ pub type NodeRenderCtxs = HashMap<InoxNodeUuid, NodeRenderCtx>;
 #[derive(Debug)]
 pub struct RenderCtx {
     pub vertex_buffers: VertexBuffers,
-    /// all nodes that need respective draw method calls
-    /// including standalone parts, composite parents
-    /// excluding plain mesh masks, composite children
+    /// All nodes that need respective draw method calls:
+    /// - including standalone parts and composite parents,
+    /// - excluding plain mesh masks and composite children.
     pub root_drawables_zsorted: Vec<InoxNodeUuid>,
     pub node_render_ctxs: NodeRenderCtxs,
 }
@@ -201,40 +201,44 @@ where
 {
     type Error;
 
-    /// do any model-specific setups, e.g. creating buffers with specific sizes
-    /// after this step, the model provided should be renderable
+    /// For any model-specific setup, e.g. creating buffers with specific sizes.
+    /// 
+    /// After this step, the provided model should be renderable.
     fn prepare(&mut self, model: &Model) -> Result<(), Self::Error>;
 
-    /// resize viewport
+    /// Resize the renderer's viewport.
     fn resize(&mut self, w: u32, h: u32);
 
-    /// clear canvas
+    /// Clear the canvas.
     fn clear(&self);
 
-    /// initiate one render pass
+    /// Initiate one render pass.
     fn on_begin_scene(&self);
-    /// the render pass
-    /// logical error if this puppet is not the latest .prepare() ed one
+    /// The render pass.
+    /// 
+    /// Logical error if this puppet is not from the latest prepared model.
     fn render(&self, puppet: &Puppet);
-    /// finish one render pass
+    /// Finish one render pass.
     fn on_end_scene(&self);
-    /// actually make results "visible", e.g. on a screen/texture
+    /// Actually make results visible, e.g. on a screen/texture.
     fn draw_scene(&self);
 
-    /// clear and start writing to stencil buffer, lock color buffer
+    /// Begin masking.
+    /// 
+    /// Clear and start writing to the stencil buffer, lock the color buffer.
     fn on_begin_mask(&self, has_mask: bool);
-    /// the following draws consist a mask or dodge mask
+    /// The following draw calls consist of a mask or dodge mask.
     fn set_mask_mode(&self, dodge: bool);
-    /// read only from stencil buffer, unlock color buffer
+    /// Read only from the stencil buffer, unlock the color buffer.
     fn on_begin_masked_content(&self);
-    /// disable stencil buffer
+    /// Disable the stencil buffer.
     fn on_end_mask(&self);
 
-    /// draw contents of a mesh-defined plain region
+    /// Draw contents of a mesh-defined plain region.
     // TODO: plain mesh (usually for mesh masks) not implemented
     fn draw_mesh_self(&self, as_mask: bool, camera: &Mat4);
 
-    /// draw contents of a part
+    /// Draw contents of a part.
     // TODO: Merging of Part and PartRenderCtx?
     // TODO: Inclusion of NodeRenderCtx into Part?
     fn draw_part_self(
@@ -246,14 +250,14 @@ where
         part_render_ctx: &PartRenderCtx,
     );
 
-    /// get ready so the following draws draw into composite buffers
+    /// When something needs to happen before drawing to the composite buffers.
     fn begin_composite_content(&self);
-    /// transfer content in composite buffers to normal buffers
+    /// Transfer content from composite buffers to normal buffers.
     fn finish_composite_content(&self, as_mask: bool, composite: &Composite);
 }
 
 pub trait InoxRendererCommon {
-    /// draw one part, with its content properly masked
+    /// Draw one part, with its content properly masked.
     fn draw_part(
         &self,
         camera: &Mat4,
@@ -263,7 +267,7 @@ pub trait InoxRendererCommon {
         puppet: &Puppet,
     );
 
-    /// draw one composite
+    /// Draw one composite.
     fn draw_composite(
         &self,
         as_mask: bool,
@@ -273,8 +277,10 @@ pub trait InoxRendererCommon {
         children: &[InoxNodeUuid],
     );
 
-    /// iterate over top-level drawables excluding masks, in zsort order, and call draws correspondingly.
-    /// this effectively draws the complete puppet
+    /// Iterate over top-level drawables (excluding masks) in zsort order,
+    /// and make draw calls correspondingly.
+    /// 
+    /// This effectively draws the complete puppet.
     fn draw(&self, camera: &Mat4, puppet: &Puppet);
 }
 

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -273,6 +273,45 @@ where
         part_render_ctx: &PartRenderCtx,
     ) -> Result<(), Self::Error>;
 
+    fn begin_composite(&self) -> Result<(), Self::Error>;
+    fn end_composite(&self) -> Result<(), Self::Error>;
+
+    fn draw_composite(
+        &self,
+        as_mask: bool,
+        camera: &Mat4,
+        composite: &Composite,
+        puppet: &Puppet,
+        children: &[InoxNodeUuid],
+    ) -> Result<(), Self::Error>;
+}
+
+pub trait InoxRendererCommon {
+    type Error;
+
+    fn draw_part(
+        &self,
+        camera: &Mat4,
+        node_render_ctx: &NodeRenderCtx,
+        part: &Part,
+        part_render_ctx: &PartRenderCtx,
+        puppet: &Puppet,
+    ) -> Result<(), Self::Error>;
+
+    fn draw_composite_self(
+        &self,
+        as_mask: bool,
+        camera: &Mat4,
+        puppet: &Puppet,
+        children: &[InoxNodeUuid],
+    ) -> Result<(), Self::Error>;
+
+    fn draw_drawables(&self, camera: &Mat4, puppet: &Puppet) -> Result<(), Self::Error>;
+}
+
+impl<T: InoxRenderer> InoxRendererCommon for T {
+    type Error = T::Error;
+
     fn draw_part(
         &self,
         camera: &Mat4,
@@ -326,9 +365,6 @@ where
         Ok(())
     }
 
-    fn begin_composite(&self) -> Result<(), Self::Error>;
-    fn end_composite(&self) -> Result<(), Self::Error>;
-
     fn draw_composite_self(
         &self,
         as_mask: bool,
@@ -358,15 +394,6 @@ where
         self.end_composite()?;
         Ok(())
     }
-
-    fn draw_composite(
-        &self,
-        as_mask: bool,
-        camera: &Mat4,
-        composite: &Composite,
-        puppet: &Puppet,
-        children: &[InoxNodeUuid],
-    ) -> Result<(), Self::Error>;
 
     fn draw_drawables(&self, camera: &Mat4, puppet: &Puppet) -> Result<(), Self::Error> {
         for &uuid in &puppet.render_ctx.drawables_zsorted {

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -227,11 +227,7 @@ pub trait InoxRenderer
 where
     Self: Sized,
 {
-    type Context;
     type Error;
-
-    /// create a new renderer, given rendering context
-    fn new(ctx: Self::Context) -> Result<Self, Self::Error>;
 
     /// do any model-specific setups, e.g. creating buffers with specific sizes
     /// after this step, the model provided should be renderable


### PR DESCRIPTION
GL renderer reimplemented using this trait.

The major part of this refactor is to finally resolve the mess of part/masks/composites being weaved together. The source of the mess is that drawables have the distinctions of `drawOne` and `drawSelf` (using ref impl terms) and "used or not, as a mask". The previous impl just blindly models the OOP pattern in the ref impl with two `bool`s being passed around. However the proper way is to factor out the commonalities instead of functions calling each other back and forth. 

Problems automatically emerged after this refactor:

0. recursive compositing just cannot happen. all checks are removed
1. find that the previous impl doesn't support simple mesh masks
2. find that the previous impl doesn't support composite node as mask
3. find that rendering to texture is not strictly enforced. in the framework there is easy way to customize the render flow
4. the data structure can be reworked a bit. after the refactor one will notice that some now separate `struct`s almost always appear together