### PR TITLE
Fix tga decoding issue

### DIFF
--- a/inox2d/src/texture/tga.rs
+++ b/inox2d/src/texture/tga.rs
@@ -229,7 +229,7 @@ pub fn read_tga<R: Read + Seek>(reader: &mut R) -> Result<TgaImage, TgaDecodeErr
 	let channels: TgaChannels = (header.bits_pp / 8).try_into().unwrap(); // bytes per pixel
 	let tchans = 4;
 	let linebuf_size = header.width * channels as u16;
-	let tline_size = header.height * tchans;
+	let tline_size = header.width * tchans;
 
 	let flip = !is_origin_at_top;
 	let tstride = if flip { -(tline_size as i32) } else { tline_size as i32 };


### PR DESCRIPTION
When loading `Aka.inx` directly, the code errors imediately (cc #80). Looking at the code it seems it's a easy fix. So I'll push the bugfix directly.

When loading `Midori.inx` it complains about lack of support for `MeshGroup`, i think that's a different story...