### PR TITLE
The map_mode parameter AngleLength is capitalized, not lowercase underscore

### DIFF
--- a/inox2d/src/formats/payload.rs
+++ b/inox2d/src/formats/payload.rs
@@ -161,7 +161,7 @@ fn deserialize_simple_physics(obj: &JsonObject) -> InoxParseResult<SimplePhysics
 	};
 
 	let map_mode = match obj.get_str("map_mode")? {
-		"angle_length" => ParamMapMode::AngleLength,
+		"AngleLength" => ParamMapMode::AngleLength,
 		"XY" => ParamMapMode::XY,
 		a => todo!("{}", a),
 	};


### PR DESCRIPTION
Simple one liner, that physics map_mode parameter gets mapped as `AngleLength`, not `angle_length`.

You can test with this one, it was created on 0.8.4 :)
[snake_questionmark.inx.zip](https://github.com/Inochi2D/inox2d/files/14470269/snake_questionmark.inx.zip)

I was also able to reproduce it with a v0.7.2-64-gbaeae68 rigged model