### PR TITLE
Bind deform buffer before uploading

### DIFF
--- a/inox2d-opengl/src/gl_buffer.rs
+++ b/inox2d-opengl/src/gl_buffer.rs
@@ -1,10 +1,10 @@
-use glow::{HasContext, NativeBuffer};
+use glow::HasContext;
 
 use inox2d::render::RenderCtx;
 
 use super::OpenglRendererError;
 
-unsafe fn upload_array_to_gl<T>(gl: &glow::Context, array: &[T], target: u32, usage: u32) -> NativeBuffer {
+unsafe fn upload_array_to_gl<T>(gl: &glow::Context, array: &[T], target: u32, usage: u32) -> glow::Buffer {
 	let bytes: &[u8] = core::slice::from_raw_parts(array.as_ptr() as *const u8, std::mem::size_of_val(array));
 	let buffer = gl.create_buffer().unwrap();
 	gl.bind_buffer(target, Some(buffer));
@@ -23,8 +23,8 @@ pub trait RenderCtxOpenglExt {
 		&self,
 		gl: &glow::Context,
 		vao: glow::VertexArray,
-	) -> Result<NativeBuffer, OpenglRendererError>;
-	unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context, buffer: NativeBuffer);
+	) -> Result<glow::Buffer, OpenglRendererError>;
+	unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context, buffer: glow::Buffer);
 }
 
 impl RenderCtxOpenglExt for RenderCtx {
@@ -41,7 +41,7 @@ impl RenderCtxOpenglExt for RenderCtx {
 		&self,
 		gl: &glow::Context,
 		vao: glow::VertexArray,
-	) -> Result<NativeBuffer, OpenglRendererError> {
+	) -> Result<glow::Buffer, OpenglRendererError> {
 		gl.bind_vertex_array(Some(vao));
 
 		upload_array_to_gl(gl, &self.vertex_buffers.verts, glow::ARRAY_BUFFER, glow::STATIC_DRAW);
@@ -71,7 +71,7 @@ impl RenderCtxOpenglExt for RenderCtx {
 	///
 	/// unsafe as initiating GL calls. can be safely called for multiple times,
 	/// but only needed once after deform update and before rendering.
-	unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context, buffer: NativeBuffer) {
+	unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context, buffer: glow::Buffer) {
 		gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer));
 
 		reupload_array_to_gl(

--- a/inox2d-opengl/src/gl_buffer.rs
+++ b/inox2d-opengl/src/gl_buffer.rs
@@ -23,7 +23,7 @@ pub trait RenderCtxOpenglExt {
 		&self,
 		gl: &glow::Context,
 		vao: glow::VertexArray,
-	) -> Result<(glow::VertexArray, NativeBuffer), OpenglRendererError>;
+	) -> Result<NativeBuffer, OpenglRendererError>;
 	unsafe fn upload_deforms_to_gl(&self, gl: &glow::Context, buffer: NativeBuffer);
 }
 
@@ -41,7 +41,7 @@ impl RenderCtxOpenglExt for RenderCtx {
 		&self,
 		gl: &glow::Context,
 		vao: glow::VertexArray,
-	) -> Result<(glow::VertexArray, NativeBuffer), OpenglRendererError> {
+	) -> Result<NativeBuffer, OpenglRendererError> {
 		gl.bind_vertex_array(Some(vao));
 
 		upload_array_to_gl(gl, &self.vertex_buffers.verts, glow::ARRAY_BUFFER, glow::STATIC_DRAW);
@@ -64,7 +64,7 @@ impl RenderCtxOpenglExt for RenderCtx {
 			glow::STATIC_DRAW,
 		);
 
-		Ok((vao, deform_buffer))
+		Ok(deform_buffer)
 	}
 
 	/// # Safety

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -184,7 +184,7 @@ impl OpenglRenderer {
 			composite_mask_shader,
 
 			textures: Vec::new(),
-			deform_buffer: NativeBuffer(NonZeroU32::MIN),
+			deform_buffer: NativeBuffer(std::num::NonZeroU32::MIN),
 		};
 
 		// Set emission strength once (it doesn't change anywhere else)

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -362,8 +362,7 @@ impl InoxRenderer for OpenglRenderer {
 	type Error = OpenglRendererError;
 
 	fn prepare(&mut self, model: &Model) -> Result<(), Self::Error> {
-		let (_, deform_buffer) = unsafe { model.puppet.render_ctx.setup_gl_buffers(&self.gl, self.vao)? };
-		self.deform_buffer = deform_buffer;
+		self.deform_buffer = unsafe { model.puppet.render_ctx.setup_gl_buffers(&self.gl, self.vao)? };
 
 		match self.upload_model_textures(&model.textures) {
 			Ok(_) => Ok(()),

--- a/inox2d-opengl/src/texture.rs
+++ b/inox2d-opengl/src/texture.rs
@@ -28,7 +28,11 @@ impl Texture {
 			gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::LINEAR as i32);
 			gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_S, glow::CLAMP_TO_BORDER as i32);
 			gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::CLAMP_TO_BORDER as i32);
+
+			// Texture parameters for f32 slices are not supported on WASM yet.
+			#[cfg(not(target_arch = "wasm32"))]
 			gl.tex_parameter_f32_slice(glow::TEXTURE_2D, glow::TEXTURE_BORDER_COLOR, &[0.0; 4]);
+
 			gl.tex_image_2d(
 				glow::TEXTURE_2D,
 				0,


### PR DESCRIPTION
Fixes deforms not working if anything else has bound to the GL_ARRAY_BUFFER