### PR TITLE
Small updates enabling loading of more v0.8 models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Rust
 /target
 /Cargo.lock
+
+# Inochi2D project/model file
+*.inp
+*.inx
+
+# renderdoc capture file
+*.cap

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "no-inline-html": false,
     "first-line-heading": false
   },
+  "cSpell.enabled": false,
   // "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
 }

--- a/inox2d/src/formats/payload.rs
+++ b/inox2d/src/formats/payload.rs
@@ -455,6 +455,8 @@ fn deserialize_binding_values(param_name: &str, values: &[JsonValue]) -> InoxPar
 
 			BindingValues::Deform(Matrix2d::from_slice_vecs(&parsed, true)?)
 		}
+		// TODO
+		"opacity" => BindingValues::Opacity,
 		param_name => return Err(InoxParseError::UnknownParamName(param_name.to_owned())),
 	})
 }

--- a/inox2d/src/formats/payload.rs
+++ b/inox2d/src/formats/payload.rs
@@ -157,6 +157,7 @@ fn deserialize_simple_physics(obj: JsonObject) -> InoxParseResult<SimplePhysics>
 		map_mode: match obj.get_str("map_mode")? {
 			"AngleLength" => PhysicsParamMapMode::AngleLength,
 			"XY" => PhysicsParamMapMode::XY,
+			"YX" => PhysicsParamMapMode::YX,
 			unknown => return Err(InoxParseError::UnknownParamMapMode(unknown.to_owned())),
 		},
 

--- a/inox2d/src/node/components.rs
+++ b/inox2d/src/node/components.rs
@@ -130,6 +130,7 @@ pub enum PhysicsModel {
 pub enum PhysicsParamMapMode {
 	AngleLength,
 	XY,
+	YX,
 }
 
 #[derive(Clone)]

--- a/inox2d/src/params.rs
+++ b/inox2d/src/params.rs
@@ -32,6 +32,8 @@ pub enum BindingValues {
 	TransformRY(Matrix2d<f32>),
 	TransformRZ(Matrix2d<f32>),
 	Deform(Matrix2d<Vec<Vec2>>),
+	// TODO
+	Opacity,
 }
 
 #[derive(Debug, Clone)]
@@ -219,6 +221,8 @@ impl Param {
 						.expect("Nodes being deformed must have a DeformStack component.")
 						.push(DeformSource::Param(self.uuid), Deform::Direct(direct_deform));
 				}
+				// TODO
+				BindingValues::Opacity => {}
 			}
 		}
 	}

--- a/inox2d/src/params.rs
+++ b/inox2d/src/params.rs
@@ -201,19 +201,19 @@ impl Param {
 							.expect("Deform param target must have an associated Mesh.");
 
 						let vert_len = mesh.vertices.len();
-							let mut direct_deform: Vec<Vec2> = Vec::with_capacity(vert_len);
-							direct_deform.resize(vert_len, Vec2::ZERO);
+						let mut direct_deform: Vec<Vec2> = Vec::with_capacity(vert_len);
+						direct_deform.resize(vert_len, Vec2::ZERO);
 
-							bi_interpolate_vec2s_additive(
-								val_normed,
-								range_in,
-								out_top,
-								out_bottom,
-								binding.interpolate_mode,
-								&mut direct_deform,
-							);
+						bi_interpolate_vec2s_additive(
+							val_normed,
+							range_in,
+							out_top,
+							out_bottom,
+							binding.interpolate_mode,
+							&mut direct_deform,
+						);
 
-							direct_deform
+						direct_deform
 					};
 
 					comps

--- a/inox2d/src/physics/pendulum.rs
+++ b/inox2d/src/physics/pendulum.rs
@@ -62,6 +62,14 @@ impl<T: Pendulum> SimplePhysicsCtx for T {
 				result.y = -result.y; // Y goes up for params
 				result
 			}
+			PhysicsParamMapMode::YX => {
+				let local_pos_norm = local_angle * relative_length;
+				let mut result = local_pos_norm - Vec2::Y;
+				result.y = -result.y; // Y goes up for params
+
+				use glam::Vec2Swizzles;
+				result.yx()
+			}
 			PhysicsParamMapMode::AngleLength => {
 				let a = f32::atan2(-local_angle.x, local_angle.y) / PI;
 				Vec2::new(a, relative_length)


### PR DESCRIPTION
Submitting my work during implementing meshgroups (so that I can load Grillo's model for testing), but are unrelated to meshgroups.

Include physics parameter mapping mode `YX` (functional) and parameter binding `opacity` (deserialization only).

A proper checklist of new features in 0.8 compared to 0.7 is needed after this and implemented orderly.