### PR TITLE
Run cargo test in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
         renderer:
           - OpenGL
         config:
-          - { name: Linux (x86),   os: ubuntu-latest,  target: "x86_64-unknown-linux-gnu" }
-          - { name: Linux (ARM),   os: ubuntu-latest,  target: "aarch64-unknown-linux-gnu" }
-          - { name: MacOS (x86),   os: macos-latest,   target: "x86_64-apple-darwin" }
-          - { name: MacOS (ARM),   os: macos-latest,   target: "aarch64-apple-darwin" }
-          - { name: Windows (x86), os: windows-latest, target: "x86_64-pc-windows-msvc" }
+          - { name: Linux (x86),   os: ubuntu-latest,    target: "x86_64-unknown-linux-gnu" }
+          - { name: Linux (ARM),   os: ubuntu-24.04-arm, target: "aarch64-unknown-linux-gnu" }
+          - { name: MacOS (x86),   os: macos-latest,     target: "x86_64-apple-darwin" }
+          - { name: MacOS (ARM),   os: macos-latest,     target: "aarch64-apple-darwin" }
+          - { name: Windows (x86), os: windows-latest,   target: "x86_64-pc-windows-msvc" }
 
     steps:
       - name: Checkout
@@ -35,14 +35,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.config.target }}
-
-      - name: Setup aarch64
-        if: matrix.config.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu
-          echo "[target.aarch64-unknown-linux-gnu]" >> ~/.cargo/config
-          echo "linker = \"aarch64-linux-gnu-gcc\"" >> ~/.cargo/config
 
       - name: Build Inox2D
         run: cargo build -p inox2d --no-default-features --features owo --all-targets --target=${{ matrix.config.target }}
@@ -54,6 +46,9 @@ jobs:
       - name: Build Example (OpenGL)
         if: matrix.renderer == 'OpenGL'
         run: cargo build -p render-opengl --all-targets --target=${{ matrix.config.target }}
+
+      - name: Test Inox2D
+        run: cargo test --target=${{ matrix.config.target }}
 
   build-webgl:
     name: Build WebGL Example


### PR DESCRIPTION
Looking to start contributing to this repository, noticed there were some existing unit tests that currently aren't being checked in the CI pipeline. This PR adds a workflow step to run them.

This also updates the runner for the amd64 build to be amd64 based, avoiding the need for installing a specific version of gcc and avoiding an issue with reqwest/openssl