### PR TITLE
Switch vertex indexes to 32-bit.

### DIFF
--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -524,8 +524,8 @@ impl InoxRenderer for OpenglRenderer {
 			gl.draw_elements(
 				glow::TRIANGLES,
 				render_ctx.index_len as i32,
-				glow::UNSIGNED_SHORT,
-				render_ctx.index_offset as i32 * mem::size_of::<u16>() as i32,
+				glow::UNSIGNED_INT,
+				render_ctx.index_offset as i32 * mem::size_of::<u32>() as i32,
 			);
 		}
 
@@ -616,7 +616,7 @@ impl InoxRenderer for OpenglRenderer {
 		}
 
 		unsafe {
-			gl.draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_SHORT, 0);
+			gl.draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_INT, 0);
 		}
 
 		self.pop_debug_group();

--- a/inox2d/src/formats/payload.rs
+++ b/inox2d/src/formats/payload.rs
@@ -219,7 +219,7 @@ fn deserialize_mesh(obj: JsonObject) -> InoxParseResult<Mesh> {
 		indices: obj
 			.get_list("indices")?
 			.iter()
-			.map_while(JsonValue::as_u16)
+			.map_while(JsonValue::as_u32)
 			.collect::<Vec<_>>(),
 		origin: obj.get_vec2("origin").unwrap_or_default(),
 	})

--- a/inox2d/src/node/components.rs
+++ b/inox2d/src/node/components.rs
@@ -193,7 +193,7 @@ pub struct Mesh {
 	/// Base UVs.
 	pub uvs: Vec<Vec2>,
 	/// Indices in the mesh.
-	pub indices: Vec<u16>,
+	pub indices: Vec<u32>,
 	/// Origin of the mesh.
 	pub origin: Vec2,
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -20,8 +20,8 @@ pub use vertex_buffers::VertexBuffers;
 ///
 /// inside `puppet.render_ctx_vertex_buffers`.
 pub struct TexturedMeshRenderCtx {
-	pub index_offset: u16,
-	pub vert_offset: u16,
+	pub index_offset: u32,
+	pub vert_offset: u32,
 	pub index_len: usize,
 	pub vert_len: usize,
 }

--- a/inox2d/src/render/vertex_buffers.rs
+++ b/inox2d/src/render/vertex_buffers.rs
@@ -5,7 +5,7 @@ use crate::node::components::Mesh;
 pub struct VertexBuffers {
 	pub verts: Vec<Vec2>,
 	pub uvs: Vec<Vec2>,
-	pub indices: Vec<u16>,
+	pub indices: Vec<u32>,
 	pub deforms: Vec<Vec2>,
 }
 
@@ -48,9 +48,9 @@ impl Default for VertexBuffers {
 
 impl VertexBuffers {
 	/// Adds the mesh's vertices and UVs to the buffers and returns its index and vertex offset.
-	pub fn push(&mut self, mesh: &Mesh) -> (u16, u16) {
-		let index_offset = self.indices.len() as u16;
-		let vert_offset = self.verts.len() as u16;
+	pub fn push(&mut self, mesh: &Mesh) -> (u32, u32) {
+		let index_offset = self.indices.len() as u32;
+		let vert_offset = self.verts.len() as u32;
 
 		self.verts.extend_from_slice(&mesh.vertices);
 		self.uvs.extend_from_slice(&mesh.uvs);


### PR DESCRIPTION
On the current inox2d, loading my model file crashes with an error about integer overflow, as I have *far* too many vertices to be indexed solely by a *mere* 16 bits.