### PR TITLE
Don't render disabled nodes

### DIFF
--- a/inox2d/src/puppet/tree.rs
+++ b/inox2d/src/puppet/tree.rs
@@ -93,4 +93,22 @@ impl InoxNodeTree {
 			.children(&self.arena)
 			.map(|id| self.arena.get(id).unwrap().get())
 	}
+
+	pub fn is_node_enabled(&self, node: InoxNodeUuid) -> bool {
+		let mut node = self.get_node(node).unwrap();
+
+		loop {
+			if !node.enabled {
+				return false;
+			}
+
+			if node.uuid == self.root_node_id {
+				break;
+			}
+
+			node = self.get_parent(node.uuid);
+		}
+
+		return true;
+	}
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -264,10 +264,17 @@ pub trait InoxRenderer {
 
 pub trait InoxRendererExt {
 	/// Draw a Drawable, which is potentially masked.
-	fn draw_drawable(&self, as_mask: bool, comps: &World, id: InoxNodeUuid);
+	fn draw_drawable(&self, puppet: &Puppet, as_mask: bool, comps: &World, id: InoxNodeUuid);
 
 	/// Draw one composite. `components` must be referencing `comps`.
-	fn draw_composite(&self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid);
+	fn draw_composite(
+		&self,
+		puppet: &Puppet,
+		as_mask: bool,
+		comps: &World,
+		components: &CompositeComponents,
+		id: InoxNodeUuid,
+	);
 
 	/// Iterate over top-level drawables (excluding masks) in zsort order,
 	/// and make draw calls correspondingly.
@@ -277,12 +284,18 @@ pub trait InoxRendererExt {
 }
 
 impl<T: InoxRenderer> InoxRendererExt for T {
-	fn draw_drawable(&self, as_mask: bool, comps: &World, id: InoxNodeUuid) {
+	fn draw_drawable(&self, puppet: &Puppet, as_mask: bool, comps: &World, id: InoxNodeUuid) {
 		let drawable_kind = DrawableKind::new(id, comps, false).expect("Node must be a Drawable.");
 		let masks = match drawable_kind {
 			DrawableKind::TexturedMesh(ref components) => &components.drawable.masks,
 			DrawableKind::Composite(ref components) => &components.drawable.masks,
 		};
+
+		let is_enabled = puppet.nodes.get_node(id).unwrap().enabled;
+		if !is_enabled && !as_mask {
+			// Disabled nodes don't render, but they can still be used as masks.
+			return;
+		}
 
 		let mut has_masks = false;
 		if let Some(ref masks) = masks {
@@ -291,7 +304,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			for mask in &masks.masks {
 				self.on_begin_mask(mask);
 
-				self.draw_drawable(true, comps, mask.source);
+				self.draw_drawable(puppet, true, comps, mask.source);
 			}
 			self.on_begin_masked_content();
 		}
@@ -300,7 +313,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			DrawableKind::TexturedMesh(ref components) => {
 				self.draw_textured_mesh_content(as_mask, components, comps.get(id).unwrap(), id)
 			}
-			DrawableKind::Composite(ref components) => self.draw_composite(as_mask, comps, components, id),
+			DrawableKind::Composite(ref components) => self.draw_composite(puppet, as_mask, comps, components, id),
 		}
 
 		if has_masks {
@@ -308,10 +321,23 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 		}
 	}
 
-	fn draw_composite(&self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid) {
+	fn draw_composite(
+		&self,
+		puppet: &Puppet,
+		as_mask: bool,
+		comps: &World,
+		components: &CompositeComponents,
+		id: InoxNodeUuid,
+	) {
 		let render_ctx = comps.get::<CompositeRenderCtx>(id).unwrap();
 		if render_ctx.zsorted_children_list.is_empty() {
 			// Optimization: Nothing to be drawn, skip context switching
+			return;
+		}
+
+		let is_enabled = puppet.nodes.get_node(id).unwrap().enabled;
+		if !is_enabled && !as_mask {
+			// Disabled nodes don't render, but they can still be used as masks.
 			return;
 		}
 
@@ -337,7 +363,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 	///
 	/// This does not guarantee the display of a puppet on screen due to these possible reasons:
 	/// - Only provided `InoxRenderer` method implementations are called.
-	/// 
+	///
 	/// For example, maybe the caller still need to transfer content from a texture buffer to the screen surface buffer.
 	/// - The provided `InoxRender` implementation is wrong.
 	/// - `puppet` here does not belong to the `model` this `renderer` is initialized with. This will likely result in panics for non-existent node uuids.
@@ -348,7 +374,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			.expect("RenderCtx of puppet must be initialized before calling draw().")
 			.root_drawables_zsorted
 		{
-			self.draw_drawable(false, &puppet.node_comps, *uuid);
+			self.draw_drawable(puppet, false, &puppet.node_comps, *uuid);
 		}
 	}
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -291,8 +291,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			DrawableKind::Composite(ref components) => &components.drawable.masks,
 		};
 
-		let is_enabled = puppet.nodes.get_node(id).unwrap().enabled;
-		if !is_enabled && !as_mask {
+		if !as_mask && !puppet.nodes.is_node_enabled(id) {
 			// Disabled nodes don't render, but they can still be used as masks.
 			return;
 		}
@@ -335,8 +334,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			return;
 		}
 
-		let is_enabled = puppet.nodes.get_node(id).unwrap().enabled;
-		if !is_enabled && !as_mask {
+		if !as_mask && !puppet.nodes.is_node_enabled(id) {
 			// Disabled nodes don't render, but they can still be used as masks.
 			return;
 		}


### PR DESCRIPTION
When a node is disabled, it does not render (but it can still be used as a mask in disabled state).

Cases I haven't investigated yet:

 * Children of disabled nodes - if I disable them in Inochi Session, they disappear. I haven't made this explicitly cascade the disabled value to children, and the renderer gets a flattened list, so...
 * Children of a disabled mask - they should still contribute to the mask, but I haven't checked.