### PR TITLE
InoxRenderer trait maintenance & updates

### DIFF
--- a/examples/render-opengl/src/main.rs
+++ b/examples/render-opengl/src/main.rs
@@ -135,9 +135,7 @@ impl App for Inox2dOpenglExampleApp {
 		// Just that physics simulation will run for the provided time, which may be big and causes a startup delay.
 		puppet.end_frame(scene_ctrl.dt());
 
-		renderer.on_begin_draw(puppet);
-		renderer.draw(puppet);
-		renderer.on_end_draw(puppet);
+		renderer.draw(puppet).expect("successful draw");
 	}
 
 	fn handle_window_event(&mut self, event: WindowEvent, elwt: &EventLoopWindowTarget<()>) {

--- a/examples/render-webgl/src/main.rs
+++ b/examples/render-webgl/src/main.rs
@@ -137,9 +137,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 				// Just that physics simulation will run for the provided time, which may be big and causes a startup delay.
 				puppet.end_frame(scene_ctrl.borrow().dt());
 
-				renderer.borrow().on_begin_draw(&puppet);
-				renderer.borrow().draw(&puppet);
-				renderer.borrow().on_end_draw(&puppet);
+				renderer.borrow_mut().draw(&puppet);
 			}
 
 			request_animation_frame(anim_loop_f.borrow().as_ref().unwrap());

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -6,6 +6,7 @@ pub mod texture;
 use std::cell::RefCell;
 use std::mem;
 use std::ops::Deref;
+use std::error::Error;
 
 use glam::{uvec2, UVec2, Vec3};
 use glow::HasContext;
@@ -410,6 +411,39 @@ impl OpenglRenderer {
 }
 
 impl InoxRenderer for OpenglRenderer {
+	/// Update the renderer with latest puppet data.
+	fn on_begin_draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>> {
+		self.push_debug_group("inox2d - begin draw");
+
+		let gl = &self.gl;
+
+		// TODO: calculate this matrix only once per draw pass.
+		// let matrix = self.camera.matrix(self.viewport.as_vec2());
+
+		unsafe {
+			gl.bind_vertex_array(Some(self.vao));
+			upload_deforms_to_gl(
+				gl,
+				puppet
+					.render_ctx
+					.as_ref()
+					.expect("Rendering for a puppet must be initialized by now.")
+					.vertex_buffers
+					.deforms
+					.as_slice(),
+				self.deform_buffer,
+			);
+			gl.enable(glow::BLEND);
+			gl.disable(glow::DEPTH_TEST);
+		}
+
+		self.pop_debug_group();
+
+		self.push_debug_group("inox2d - draw");
+
+		Ok(())
+	}
+
 	fn on_begin_masks(&mut self, masks: &Masks) {
 		self.push_debug_group("inox2d - begin masks");
 
@@ -621,42 +655,9 @@ impl InoxRenderer for OpenglRenderer {
 
 		self.pop_debug_group();
 	}
-}
-
-impl OpenglRenderer {
-	/// Update the renderer with latest puppet data.
-	pub fn on_begin_draw(&self, puppet: &Puppet) {
-		self.push_debug_group("inox2d - begin draw");
-
-		let gl = &self.gl;
-
-		// TODO: calculate this matrix only once per draw pass.
-		// let matrix = self.camera.matrix(self.viewport.as_vec2());
-
-		unsafe {
-			gl.bind_vertex_array(Some(self.vao));
-			upload_deforms_to_gl(
-				gl,
-				puppet
-					.render_ctx
-					.as_ref()
-					.expect("Rendering for a puppet must be initialized by now.")
-					.vertex_buffers
-					.deforms
-					.as_slice(),
-				self.deform_buffer,
-			);
-			gl.enable(glow::BLEND);
-			gl.disable(glow::DEPTH_TEST);
-		}
-
-		self.pop_debug_group();
-
-		self.push_debug_group("inox2d - draw");
-	}
 
 	/// Renderer cleaning up after one frame.
-	pub fn on_end_draw(&self, _puppet: &Puppet) {
+	fn on_end_draw(&mut self, _puppet: &Puppet) {
 		self.pop_debug_group();
 
 		self.push_debug_group("inox2d - end draw");

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -4,9 +4,9 @@ mod shaders;
 pub mod texture;
 
 use std::cell::RefCell;
+use std::error::Error;
 use std::mem;
 use std::ops::Deref;
-use std::error::Error;
 
 use glam::{uvec2, UVec2, Vec3};
 use glow::HasContext;
@@ -19,7 +19,7 @@ use inox2d::node::{
 	InoxNodeUuid,
 };
 use inox2d::puppet::Puppet;
-use inox2d::render::{CompositeRenderCtx, InoxRenderer, TexturedMeshRenderCtx};
+use inox2d::render::{CompositeRenderCtx, DrawSession, InoxRenderer, TexturedMeshRenderCtx};
 use inox2d::texture::{decode_model_textures, TextureId};
 
 use self::shader::ShaderCompileError;
@@ -411,8 +411,13 @@ impl OpenglRenderer {
 }
 
 impl InoxRenderer for OpenglRenderer {
+	type Draw<'a>
+		= OpenGlSession<'a>
+	where
+		Self: 'a;
+
 	/// Update the renderer with latest puppet data.
-	fn on_begin_draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>> {
+	fn on_begin_draw<'a>(&'a mut self, puppet: &Puppet) -> Result<Self::Draw<'a>, Box<dyn Error>> {
 		self.push_debug_group("inox2d - begin draw");
 
 		let gl = &self.gl;
@@ -441,13 +446,19 @@ impl InoxRenderer for OpenglRenderer {
 
 		self.push_debug_group("inox2d - draw");
 
-		Ok(())
+		Ok(OpenGlSession { render: self })
 	}
+}
 
+pub struct OpenGlSession<'a> {
+	render: &'a mut OpenglRenderer,
+}
+
+impl<'a> DrawSession<'a> for OpenGlSession<'a> {
 	fn on_begin_masks(&mut self, masks: &Masks) {
-		self.push_debug_group("inox2d - begin masks");
+		self.render.push_debug_group("inox2d - begin masks");
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 
 		unsafe {
 			gl.enable(glow::STENCIL_TEST);
@@ -459,26 +470,26 @@ impl InoxRenderer for OpenglRenderer {
 			gl.stencil_mask(0xff);
 		}
 
-		let part_mask_shader = &self.part_mask_shader;
-		self.bind_shader(part_mask_shader);
+		let part_mask_shader = &self.render.part_mask_shader;
+		self.render.bind_shader(part_mask_shader);
 		part_mask_shader.set_threshold(gl, masks.threshold.clamp(0.0, 1.0));
 
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 	}
 
 	fn on_begin_mask(&mut self, mask: &Mask) {
-		self.push_debug_group("inox2d - begin mask");
+		self.render.push_debug_group("inox2d - begin mask");
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 		unsafe {
 			gl.stencil_func(glow::ALWAYS, (mask.mode == MaskMode::Mask) as i32, 0xff);
 		}
 	}
 
 	fn on_begin_masked_content(&mut self) {
-		self.push_debug_group("inox2d - begin masked content");
+		self.render.push_debug_group("inox2d - begin masked content");
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 		unsafe {
 			gl.stencil_func(glow::EQUAL, 1, 0xff);
 			gl.stencil_mask(0x00);
@@ -486,18 +497,18 @@ impl InoxRenderer for OpenglRenderer {
 			gl.color_mask(true, true, true, true);
 		}
 
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 	}
 
 	fn on_end_mask(&mut self) {
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 		unsafe {
 			gl.stencil_mask(0xff);
 			gl.stencil_func(glow::ALWAYS, 1, 0xff);
 			gl.disable(glow::STENCIL_TEST);
 		}
-		
-		self.pop_debug_group();
+
+		self.render.pop_debug_group();
 	}
 
 	fn draw_textured_mesh_content(
@@ -507,9 +518,9 @@ impl InoxRenderer for OpenglRenderer {
 		render_ctx: &TexturedMeshRenderCtx,
 		_id: InoxNodeUuid,
 	) {
-		self.push_debug_group("inox2d - draw textured content");
+		self.render.push_debug_group("inox2d - draw textured content");
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 
 		// TODO: plain masks, meshes as masks without textures
 		/*
@@ -529,10 +540,10 @@ impl InoxRenderer for OpenglRenderer {
 		glDisableVertexAttribArray(0);
 		*/
 
-		self.bind_part_textures(components.texture);
-		self.set_blend_mode(components.drawable.blending.mode);
+		self.render.bind_part_textures(components.texture);
+		self.render.set_blend_mode(components.drawable.blending.mode);
 
-		let mvp = self.camera.matrix(self.viewport.as_vec2()) * *components.transform;
+		let mvp = self.render.camera.matrix(self.render.viewport.as_vec2()) * *components.transform;
 
 		if as_mask {
 			// if as_mask is set, in .on_begin_masks():
@@ -540,10 +551,10 @@ impl InoxRenderer for OpenglRenderer {
 			// - mask threshold must have been uploaded.
 
 			// vert uniforms
-			self.part_mask_shader.set_mvp(gl, mvp);
+			self.render.part_mask_shader.set_mvp(gl, mvp);
 		} else {
-			let part_shader = &self.part_shader;
-			self.bind_shader(part_shader);
+			let part_shader = &self.render.part_shader;
+			self.render.bind_shader(part_shader);
 
 			// vert uniforms
 			part_shader.set_mvp(gl, mvp);
@@ -563,7 +574,7 @@ impl InoxRenderer for OpenglRenderer {
 			);
 		}
 
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 	}
 
 	fn begin_composite_content(
@@ -573,13 +584,13 @@ impl InoxRenderer for OpenglRenderer {
 		_render_ctx: &CompositeRenderCtx,
 		_id: InoxNodeUuid,
 	) {
-		self.push_debug_group("inox2d - begin composite content");
+		self.render.push_debug_group("inox2d - begin composite content");
 
-		self.clear_texture_cache();
+		self.render.clear_texture_cache();
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 		unsafe {
-			gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(self.composite_framebuffer));
+			gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, Some(self.render.composite_framebuffer));
 			gl.disable(glow::DEPTH_TEST);
 			gl.draw_buffers(&[
 				glow::COLOR_ATTACHMENT0,
@@ -594,9 +605,9 @@ impl InoxRenderer for OpenglRenderer {
 			gl.blend_func(glow::ONE, glow::ONE_MINUS_SRC_ALPHA);
 		}
 
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 
-		self.push_debug_group("inox2d - composite content");
+		self.render.push_debug_group("inox2d - composite content");
 	}
 
 	fn finish_composite_content(
@@ -606,13 +617,13 @@ impl InoxRenderer for OpenglRenderer {
 		_render_ctx: &CompositeRenderCtx,
 		_id: InoxNodeUuid,
 	) {
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 
-		self.push_debug_group("inox2d - finish composite content");
+		self.render.push_debug_group("inox2d - finish composite content");
 
-		let gl = &self.gl;
+		let gl = &self.render.gl;
 
-		self.clear_texture_cache();
+		self.render.clear_texture_cache();
 		unsafe {
 			gl.bind_framebuffer(glow::FRAMEBUFFER, None);
 		}
@@ -629,21 +640,21 @@ impl InoxRenderer for OpenglRenderer {
 		} else {
 			unsafe {
 				gl.active_texture(glow::TEXTURE0);
-				gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_albedo));
+				gl.bind_texture(glow::TEXTURE_2D, Some(self.render.cf_albedo));
 				gl.active_texture(glow::TEXTURE1);
-				gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_emissive));
+				gl.bind_texture(glow::TEXTURE_2D, Some(self.render.cf_emissive));
 				gl.active_texture(glow::TEXTURE2);
-				gl.bind_texture(glow::TEXTURE_2D, Some(self.cf_bump));
+				gl.bind_texture(glow::TEXTURE_2D, Some(self.render.cf_bump));
 			}
 
-			self.set_blend_mode(blending.mode);
+			self.render.set_blend_mode(blending.mode);
 
 			let opacity = blending.opacity.clamp(0.0, 1.0);
 			let tint = blending.tint.clamp(Vec3::ZERO, Vec3::ONE);
 			let screen_tint = blending.screen_tint.clamp(Vec3::ZERO, Vec3::ONE);
 
-			let composite_shader = &self.composite_shader;
-			self.bind_shader(composite_shader);
+			let composite_shader = &self.render.composite_shader;
+			self.render.bind_shader(composite_shader);
 			composite_shader.set_opacity(gl, opacity);
 			composite_shader.set_mult_color(gl, tint);
 			composite_shader.set_screen_color(gl, screen_tint);
@@ -653,20 +664,20 @@ impl InoxRenderer for OpenglRenderer {
 			gl.draw_elements(glow::TRIANGLES, 6, glow::UNSIGNED_INT, 0);
 		}
 
-		self.pop_debug_group();
+		self.render.pop_debug_group();
 	}
 
 	/// Renderer cleaning up after one frame.
-	fn on_end_draw(&mut self, _puppet: &Puppet) {
-		self.pop_debug_group();
+	fn on_end_draw(self, _puppet: &Puppet) {
+		self.render.pop_debug_group();
 
-		self.push_debug_group("inox2d - end draw");
-		
-		let gl = &self.gl;
+		self.render.push_debug_group("inox2d - end draw");
+
+		let gl = &self.render.gl;
 		unsafe {
 			gl.bind_vertex_array(None);
 		}
-		
-		self.pop_debug_group();
+
+		self.render.pop_debug_group();
 	}
 }

--- a/inox2d-opengl/src/lib.rs
+++ b/inox2d-opengl/src/lib.rs
@@ -410,7 +410,7 @@ impl OpenglRenderer {
 }
 
 impl InoxRenderer for OpenglRenderer {
-	fn on_begin_masks(&self, masks: &Masks) {
+	fn on_begin_masks(&mut self, masks: &Masks) {
 		self.push_debug_group("inox2d - begin masks");
 
 		let gl = &self.gl;
@@ -432,7 +432,7 @@ impl InoxRenderer for OpenglRenderer {
 		self.pop_debug_group();
 	}
 
-	fn on_begin_mask(&self, mask: &Mask) {
+	fn on_begin_mask(&mut self, mask: &Mask) {
 		self.push_debug_group("inox2d - begin mask");
 
 		let gl = &self.gl;
@@ -441,7 +441,7 @@ impl InoxRenderer for OpenglRenderer {
 		}
 	}
 
-	fn on_begin_masked_content(&self) {
+	fn on_begin_masked_content(&mut self) {
 		self.push_debug_group("inox2d - begin masked content");
 
 		let gl = &self.gl;
@@ -455,7 +455,7 @@ impl InoxRenderer for OpenglRenderer {
 		self.pop_debug_group();
 	}
 
-	fn on_end_mask(&self) {
+	fn on_end_mask(&mut self) {
 		let gl = &self.gl;
 		unsafe {
 			gl.stencil_mask(0xff);
@@ -467,7 +467,7 @@ impl InoxRenderer for OpenglRenderer {
 	}
 
 	fn draw_textured_mesh_content(
-		&self,
+		&mut self,
 		as_mask: bool,
 		components: &TexturedMeshComponents,
 		render_ctx: &TexturedMeshRenderCtx,
@@ -533,7 +533,7 @@ impl InoxRenderer for OpenglRenderer {
 	}
 
 	fn begin_composite_content(
-		&self,
+		&mut self,
 		_as_mask: bool,
 		_components: &CompositeComponents,
 		_render_ctx: &CompositeRenderCtx,
@@ -566,7 +566,7 @@ impl InoxRenderer for OpenglRenderer {
 	}
 
 	fn finish_composite_content(
-		&self,
+		&mut self,
 		as_mask: bool,
 		components: &CompositeComponents,
 		_render_ctx: &CompositeRenderCtx,

--- a/inox2d/src/node/drawables.rs
+++ b/inox2d/src/node/drawables.rs
@@ -38,7 +38,7 @@ impl<'comps> DrawableKind<'comps> {
 	/// `None` if node not renderable.
 	///
 	/// If `check`, will send a warning to `tracing` if component combination non-standard for a supposed-to-be Drawable node.
-	pub(crate) fn new(id: InoxNodeUuid, comps: &'comps World, check: bool) -> Option<Self> {
+	pub fn new(id: InoxNodeUuid, comps: &'comps World, check: bool) -> Option<Self> {
 		let drawable = match comps.get::<Drawable>(id) {
 			Some(drawable) => drawable,
 			None => return None,

--- a/inox2d/src/node/drawables.rs
+++ b/inox2d/src/node/drawables.rs
@@ -11,7 +11,7 @@ use crate::puppet::World;
 /// Future spec extensions go here.
 /// For user-defined custom nodes that can be rendered, as long as a subset of their components matches one of these variants,
 /// they will be picked up and enter the regular rendering pipeline.
-pub(crate) enum DrawableKind<'comps> {
+pub enum DrawableKind<'comps> {
 	TexturedMesh(TexturedMeshComponents<'comps>),
 	Composite(CompositeComponents<'comps>),
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -3,6 +3,7 @@ mod vertex_buffers;
 
 use std::collections::HashSet;
 use std::mem::swap;
+use std::error::Error;
 
 use crate::node::{
 	components::{DeformStack, Mask, Masks, ZSort},
@@ -215,25 +216,33 @@ impl RenderCtx {
 ///
 /// Either way, the point is Inox2D will implement a `draw()` method for any `impl InoxRenderer`, dispatching calls based on puppet structure according to Inochi2D standard.
 pub trait InoxRenderer {
+	/// Begin rendering a whole puppet.
+	/// 
+	/// Calls to `begin_render()` and `end_render_and_flush()` must be
+	/// balanced. Failure to balance these calls will result in a panic.
+	fn begin_render(&mut self) -> Result<(), Box<dyn Error>> {
+		Ok(())
+	}
+
 	/// Begin masking.
 	///
 	/// Ref impl: Clear and start writing to the stencil buffer, lock the color buffer.
-	fn on_begin_masks(&self, masks: &Masks);
+	fn on_begin_masks(&mut self, masks: &Masks);
 	/// Get prepared for rendering a singular Mask.
-	fn on_begin_mask(&self, mask: &Mask);
+	fn on_begin_mask(&mut self, mask: &Mask);
 	/// Get prepared for rendering masked content.
 	///
 	/// Ref impl: Read only from the stencil buffer, unlock the color buffer.
-	fn on_begin_masked_content(&self);
+	fn on_begin_masked_content(&mut self);
 	/// End masking.
 	///
 	/// Ref impl: Disable the stencil buffer.
-	fn on_end_mask(&self);
+	fn on_end_mask(&mut self);
 
 	/// Draw TexturedMesh content.
 	// TODO: TexturedMesh without any texture (usually for mesh masks)?
 	fn draw_textured_mesh_content(
-		&self,
+		&mut self,
 		as_mask: bool,
 		components: &TexturedMeshComponents,
 		render_ctx: &TexturedMeshRenderCtx,
@@ -244,7 +253,7 @@ pub trait InoxRenderer {
 	///
 	/// Ref impl: Prepare composite buffers.
 	fn begin_composite_content(
-		&self,
+		&mut self,
 		as_mask: bool,
 		components: &CompositeComponents,
 		render_ctx: &CompositeRenderCtx,
@@ -254,30 +263,34 @@ pub trait InoxRenderer {
 	///
 	/// Ref impl: Transfer content from composite buffers to normal buffers.
 	fn finish_composite_content(
-		&self,
+		&mut self,
 		as_mask: bool,
 		components: &CompositeComponents,
 		render_ctx: &CompositeRenderCtx,
 		id: InoxNodeUuid,
 	);
+
+	/// Finish rendering, flush any pending operations, and present the puppet
+	/// to the given display.
+	fn end_render_and_flush(&mut self) {}
 }
 
 pub trait InoxRendererExt {
 	/// Draw a Drawable, which is potentially masked.
-	fn draw_drawable(&self, as_mask: bool, comps: &World, id: InoxNodeUuid);
+	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid);
 
 	/// Draw one composite. `components` must be referencing `comps`.
-	fn draw_composite(&self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid);
+	fn draw_composite(&mut self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid);
 
 	/// Iterate over top-level drawables (excluding masks) in zsort order,
 	/// and make draw calls correspondingly.
 	///
 	/// This effectively draws the complete puppet.
-	fn draw(&self, puppet: &Puppet);
+	fn draw(&mut self, puppet: &Puppet);
 }
 
 impl<T: InoxRenderer> InoxRendererExt for T {
-	fn draw_drawable(&self, as_mask: bool, comps: &World, id: InoxNodeUuid) {
+	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid) {
 		let drawable_kind = DrawableKind::new(id, comps, false).expect("Node must be a Drawable.");
 		let masks = match drawable_kind {
 			DrawableKind::TexturedMesh(ref components) => &components.drawable.masks,
@@ -308,7 +321,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 		}
 	}
 
-	fn draw_composite(&self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid) {
+	fn draw_composite(&mut self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid) {
 		let render_ctx = comps.get::<CompositeRenderCtx>(id).unwrap();
 		if render_ctx.zsorted_children_list.is_empty() {
 			// Optimization: Nothing to be drawn, skip context switching
@@ -341,7 +354,9 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 	/// For example, maybe the caller still need to transfer content from a texture buffer to the screen surface buffer.
 	/// - The provided `InoxRender` implementation is wrong.
 	/// - `puppet` here does not belong to the `model` this `renderer` is initialized with. This will likely result in panics for non-existent node uuids.
-	fn draw(&self, puppet: &Puppet) {
+	fn draw(&mut self, puppet: &Puppet) {
+		self.begin_render();
+
 		for uuid in &puppet
 			.render_ctx
 			.as_ref()
@@ -350,5 +365,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 		{
 			self.draw_drawable(false, &puppet.node_comps, *uuid);
 		}
+
+		self.end_render_and_flush();
 	}
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -204,6 +204,15 @@ impl RenderCtx {
 			.zip(root_drawable_uuid_zsort_vec.iter())
 			.for_each(|(old, new)| *old = new.0);
 	}
+
+	/// Retrieve the list of root drawables for this render context.
+	///
+	/// A "root drawable" consists of any node that directly contributes to the
+	/// render output. Masks and composite children, notably, are not
+	/// considered root drawable.
+	pub fn root_drawables_zsorted(&self) -> &[InoxNodeUuid] {
+		self.root_drawables_zsorted.as_slice()
+	}
 }
 
 /// Same as the reference Inochi2D implementation, Inox2D also aims for a "bring your own rendering backend" design.

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -281,10 +281,17 @@ pub trait DrawSession<'a> {
 
 pub trait DrawSessionExt {
 	/// Draw a Drawable, which is potentially masked.
-	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid);
+	fn draw_drawable(&mut self, puppet: &Puppet, as_mask: bool, comps: &World, id: InoxNodeUuid);
 
 	/// Draw one composite. `components` must be referencing `comps`.
-	fn draw_composite(&mut self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid);
+	fn draw_composite(
+		&mut self,
+		puppet: &Puppet,
+		as_mask: bool,
+		comps: &World,
+		components: &CompositeComponents,
+		id: InoxNodeUuid,
+	);
 }
 
 pub trait InoxRendererExt {
@@ -296,7 +303,7 @@ pub trait InoxRendererExt {
 }
 
 impl<'a, T: DrawSession<'a>> DrawSessionExt for T {
-	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid) {
+	fn draw_drawable(&mut self, puppet: &Puppet, as_mask: bool, comps: &World, id: InoxNodeUuid) {
 		let drawable_kind = DrawableKind::new(id, comps, false).expect("Node must be a Drawable.");
 		let masks = match drawable_kind {
 			DrawableKind::TexturedMesh(ref components) => &components.drawable.masks,
@@ -310,7 +317,7 @@ impl<'a, T: DrawSession<'a>> DrawSessionExt for T {
 			for mask in &masks.masks {
 				self.on_begin_mask(mask);
 
-				self.draw_drawable(true, comps, mask.source);
+				self.draw_drawable(puppet, true, comps, mask.source);
 			}
 			self.on_begin_masked_content();
 		}
@@ -319,7 +326,7 @@ impl<'a, T: DrawSession<'a>> DrawSessionExt for T {
 			DrawableKind::TexturedMesh(ref components) => {
 				self.draw_textured_mesh_content(as_mask, components, comps.get(id).unwrap(), id)
 			}
-			DrawableKind::Composite(ref components) => self.draw_composite(as_mask, comps, components, id),
+			DrawableKind::Composite(ref components) => self.draw_composite(puppet, as_mask, comps, components, id),
 		}
 
 		if has_masks {
@@ -327,10 +334,23 @@ impl<'a, T: DrawSession<'a>> DrawSessionExt for T {
 		}
 	}
 
-	fn draw_composite(&mut self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid) {
+	fn draw_composite(
+		&mut self,
+		puppet: &Puppet,
+		as_mask: bool,
+		comps: &World,
+		components: &CompositeComponents,
+		id: InoxNodeUuid,
+	) {
 		let render_ctx = comps.get::<CompositeRenderCtx>(id).unwrap();
 		if render_ctx.zsorted_children_list.is_empty() {
 			// Optimization: Nothing to be drawn, skip context switching
+			return;
+		}
+
+		let is_enabled = puppet.nodes.get_node(id).unwrap().enabled;
+		if !is_enabled && !as_mask {
+			// Disabled nodes don't render, but they can still be used as masks.
 			return;
 		}
 
@@ -371,7 +391,7 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			.expect("RenderCtx of puppet must be initialized before calling draw().")
 			.root_drawables_zsorted
 		{
-			draw.draw_drawable(false, &puppet.node_comps, *uuid);
+			draw.draw_drawable(puppet, false, &puppet.node_comps, *uuid);
 		}
 
 		draw.on_end_draw(puppet);

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -218,11 +218,9 @@ impl RenderCtx {
 pub trait InoxRenderer {
 	/// Begin rendering a whole puppet.
 	/// 
-	/// Calls to `begin_render()` and `end_render_and_flush()` must be
+	/// Calls to `on_begin_draw()` and `on_end_draw()` must be
 	/// balanced. Failure to balance these calls will result in a panic.
-	fn begin_render(&mut self) -> Result<(), Box<dyn Error>> {
-		Ok(())
-	}
+	fn on_begin_draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>>;
 
 	/// Begin masking.
 	///
@@ -272,7 +270,7 @@ pub trait InoxRenderer {
 
 	/// Finish rendering, flush any pending operations, and present the puppet
 	/// to the given display.
-	fn end_render_and_flush(&mut self) {}
+	fn on_end_draw(&mut self, puppet: &Puppet);
 }
 
 pub trait InoxRendererExt {
@@ -286,7 +284,7 @@ pub trait InoxRendererExt {
 	/// and make draw calls correspondingly.
 	///
 	/// This effectively draws the complete puppet.
-	fn draw(&mut self, puppet: &Puppet);
+	fn draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>>;
 }
 
 impl<T: InoxRenderer> InoxRendererExt for T {
@@ -354,8 +352,8 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 	/// For example, maybe the caller still need to transfer content from a texture buffer to the screen surface buffer.
 	/// - The provided `InoxRender` implementation is wrong.
 	/// - `puppet` here does not belong to the `model` this `renderer` is initialized with. This will likely result in panics for non-existent node uuids.
-	fn draw(&mut self, puppet: &Puppet) {
-		self.begin_render();
+	fn draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>> {
+		self.on_begin_draw(puppet)?;
 
 		for uuid in &puppet
 			.render_ctx
@@ -366,6 +364,8 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			self.draw_drawable(false, &puppet.node_comps, *uuid);
 		}
 
-		self.end_render_and_flush();
+		self.on_end_draw(puppet);
+
+		Ok(())
 	}
 }

--- a/inox2d/src/render.rs
+++ b/inox2d/src/render.rs
@@ -2,8 +2,8 @@ mod deform_stack;
 mod vertex_buffers;
 
 use std::collections::HashSet;
-use std::mem::swap;
 use std::error::Error;
+use std::mem::swap;
 
 use crate::node::{
 	components::{DeformStack, Mask, Masks, ZSort},
@@ -216,12 +216,18 @@ impl RenderCtx {
 ///
 /// Either way, the point is Inox2D will implement a `draw()` method for any `impl InoxRenderer`, dispatching calls based on puppet structure according to Inochi2D standard.
 pub trait InoxRenderer {
+	type Draw<'a>: DrawSession<'a>
+	where
+		Self: 'a;
+
 	/// Begin rendering a whole puppet.
-	/// 
+	///
 	/// Calls to `on_begin_draw()` and `on_end_draw()` must be
 	/// balanced. Failure to balance these calls will result in a panic.
-	fn on_begin_draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>>;
+	fn on_begin_draw<'a>(&'a mut self, puppet: &Puppet) -> Result<Self::Draw<'a>, Box<dyn Error>>;
+}
 
+pub trait DrawSession<'a> {
 	/// Begin masking.
 	///
 	/// Ref impl: Clear and start writing to the stencil buffer, lock the color buffer.
@@ -270,16 +276,18 @@ pub trait InoxRenderer {
 
 	/// Finish rendering, flush any pending operations, and present the puppet
 	/// to the given display.
-	fn on_end_draw(&mut self, puppet: &Puppet);
+	fn on_end_draw(self, puppet: &Puppet);
 }
 
-pub trait InoxRendererExt {
+pub trait DrawSessionExt {
 	/// Draw a Drawable, which is potentially masked.
 	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid);
 
 	/// Draw one composite. `components` must be referencing `comps`.
 	fn draw_composite(&mut self, as_mask: bool, comps: &World, components: &CompositeComponents, id: InoxNodeUuid);
+}
 
+pub trait InoxRendererExt {
 	/// Iterate over top-level drawables (excluding masks) in zsort order,
 	/// and make draw calls correspondingly.
 	///
@@ -287,7 +295,7 @@ pub trait InoxRendererExt {
 	fn draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>>;
 }
 
-impl<T: InoxRenderer> InoxRendererExt for T {
+impl<'a, T: DrawSession<'a>> DrawSessionExt for T {
 	fn draw_drawable(&mut self, as_mask: bool, comps: &World, id: InoxNodeUuid) {
 		let drawable_kind = DrawableKind::new(id, comps, false).expect("Node must be a Drawable.");
 		let masks = match drawable_kind {
@@ -341,19 +349,21 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 
 		self.finish_composite_content(as_mask, components, render_ctx, id);
 	}
+}
 
+impl<T: InoxRenderer> InoxRendererExt for T {
 	/// Dispatches draw calls for all nodes of `puppet`
 	/// - with provided renderer implementation,
 	/// - in Inochi2D standard defined order.
 	///
 	/// This does not guarantee the display of a puppet on screen due to these possible reasons:
 	/// - Only provided `InoxRenderer` method implementations are called.
-	/// 
+	///
 	/// For example, maybe the caller still need to transfer content from a texture buffer to the screen surface buffer.
 	/// - The provided `InoxRender` implementation is wrong.
 	/// - `puppet` here does not belong to the `model` this `renderer` is initialized with. This will likely result in panics for non-existent node uuids.
 	fn draw(&mut self, puppet: &Puppet) -> Result<(), Box<dyn Error>> {
-		self.on_begin_draw(puppet)?;
+		let mut draw = self.on_begin_draw(puppet)?;
 
 		for uuid in &puppet
 			.render_ctx
@@ -361,10 +371,10 @@ impl<T: InoxRenderer> InoxRendererExt for T {
 			.expect("RenderCtx of puppet must be initialized before calling draw().")
 			.root_drawables_zsorted
 		{
-			self.draw_drawable(false, &puppet.node_comps, *uuid);
+			draw.draw_drawable(false, &puppet.node_comps, *uuid);
 		}
 
-		self.on_end_draw(puppet);
+		draw.on_end_draw(puppet);
 
 		Ok(())
 	}


### PR DESCRIPTION
This PR contains various rendering trait improvements that are necessary for other PRs I've filed, notably the wgpu renderer in #112 and disabled node hiding in #114.

 * `InoxRenderer` methods now always take `&mut self`, so renderers don't have to use interior mutability.
   * This is predominantly necessary for wgpu (see #112) which does not carry nearly as much mutable state as OpenGL does.
   * I did not remove the existing interior mutability surrounding `GlCache` as it caused borrow checker issues in the OpenGL renderer.
 * `on_begin_draw` and `on_end_draw` have been promoted to proper trait methods.
   * This allows renderers to always set up state before drawing happens.
   * `InoxRendererExt` now calls these methods correctly in `draw`, so the OpenGL example app doesn't have to.
 * `on_begin_draw` now returns a `DrawSession<'_>` struct that can own its own resources.
   * This removed a significant amount of call sequencing checks (e.g. "are we in a draw pass already?") and `if let Some()` blocks from the wgpu renderer.
   * `DrawSession` is a trait with an associated lifetime so that the draw session can also reference renderer resources.
   * `InoxRenderer` impls provide a generic associated type called `Draw` which their `on_begin_draw` is supposed to call.
   * `on_end_draw` is used to signal the end of drawing and request presentation to the screen. We specifically do *not* use `Drop` for this, in keeping with the convention that dropping a `Future` cancels the associated work.
 * Added `&Puppet` parameter to all `DrawSessionExt` methods (needed for #114)