### PR TITLE
Add a method to calculate a Puppet's bounds

### DIFF
--- a/inox2d/src/math.rs
+++ b/inox2d/src/math.rs
@@ -2,4 +2,5 @@ pub mod camera;
 pub mod deform;
 pub mod interp;
 pub mod matrix;
+pub mod rect;
 pub mod transform;

--- a/inox2d/src/math/rect.rs
+++ b/inox2d/src/math/rect.rs
@@ -19,13 +19,13 @@ impl Rect {
 
 		if point.x < child.top_left.x {
 			child.top_left.x = point.x;
-		} else if child.bottom_right.x > point.x {
+		} else if point.x > child.bottom_right.x {
 			child.bottom_right.x = point.x;
 		}
 
 		if point.y < child.top_left.y {
 			child.top_left.y = point.y;
-		} else if child.bottom_right.y > point.y {
+		} else if point.y > child.bottom_right.y {
 			child.bottom_right.y = point.y;
 		}
 

--- a/inox2d/src/math/rect.rs
+++ b/inox2d/src/math/rect.rs
@@ -1,14 +1,14 @@
 use glam::Vec2;
 
 #[derive(Clone, Copy)]
-pub struct Rect {
+pub struct RectBounds {
 	top_left: Vec2,
 	bottom_right: Vec2,
 }
 
-impl Rect {
+impl RectBounds {
 	pub fn from_point(point: Vec2) -> Self {
-		Rect {
+		RectBounds {
 			top_left: point,
 			bottom_right: point,
 		}

--- a/inox2d/src/math/rect.rs
+++ b/inox2d/src/math/rect.rs
@@ -31,4 +31,20 @@ impl Rect {
 
 		child
 	}
+
+	pub fn width(&self) -> f32 {
+		self.bottom_right.x - self.top_left.x
+	}
+
+	pub fn height(&self) -> f32 {
+		self.bottom_right.y - self.top_left.y
+	}
+
+	pub fn top_left_point(&self) -> Vec2 {
+		self.top_left
+	}
+
+	pub fn bottom_right_point(&self) -> Vec2 {
+		self.bottom_right
+	}
 }

--- a/inox2d/src/math/rect.rs
+++ b/inox2d/src/math/rect.rs
@@ -1,0 +1,34 @@
+use glam::Vec2;
+
+#[derive(Clone, Copy)]
+pub struct Rect {
+	top_left: Vec2,
+	bottom_right: Vec2,
+}
+
+impl Rect {
+	pub fn from_point(point: Vec2) -> Self {
+		Rect {
+			top_left: point,
+			bottom_right: point,
+		}
+	}
+
+	pub fn with_union_point(&self, point: Vec2) -> Self {
+		let mut child = *self;
+
+		if point.x < child.top_left.x {
+			child.top_left.x = point.x;
+		} else if child.bottom_right.x > point.x {
+			child.bottom_right.x = point.x;
+		}
+
+		if point.y < child.top_left.y {
+			child.top_left.y = point.y;
+		} else if child.bottom_right.y > point.y {
+			child.bottom_right.y = point.y;
+		}
+
+		child
+	}
+}

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -184,7 +184,7 @@ impl Puppet {
 				for vert in &mesh.vertices {
 					let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 1.0)).xy();
 					out = match out {
-						None => Some(Rect::from_point(vert)),
+						None => Some(RectBounds::from_point(vert)),
 						Some(rect) => Some(rect.with_union_point(vert)),
 					};
 				}

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -6,7 +6,7 @@ mod world;
 use std::collections::HashMap;
 
 use crate::math::rect::Rect;
-use crate::node::drawables::TexturedMeshComponents;
+use crate::node::components::{Mesh, TransformStore};
 use crate::node::{InoxNode, InoxNodeUuid};
 use crate::params::{Param, ParamCtx};
 use crate::physics::{PhysicsCtx, PuppetPhysics};
@@ -175,11 +175,11 @@ impl Puppet {
 	pub fn bounds(&self) -> Option<Rect> {
 		let mut out = None;
 		for node in self.nodes.iter() {
-			if let Some(tmc) = self.node_comps.get::<TexturedMeshComponents>(node.uuid) {
-				let mvp = tmc.transform;
+			if let (Some(transform), Some(mesh)) = (self.node_comps.get::<TransformStore>(node.uuid), self.node_comps.get::<Mesh>(node.uuid)) {
+				let mvp = transform.absolute;
 
-				for index in &tmc.mesh.indices {
-					if let Some(vert) = tmc.mesh.vertices.get(*index as usize) {
+				for index in &mesh.indices {
+					if let Some(vert) = mesh.vertices.get(*index as usize) {
 						let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 0.0)).xy();
 						out = match out {
 							None => Some(Rect::from_point(vert)),

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -175,12 +175,15 @@ impl Puppet {
 	pub fn bounds(&self) -> Option<Rect> {
 		let mut out = None;
 		for node in self.nodes.iter() {
-			if let (Some(transform), Some(mesh)) = (self.node_comps.get::<TransformStore>(node.uuid), self.node_comps.get::<Mesh>(node.uuid)) {
+			if let (Some(transform), Some(mesh)) = (
+				self.node_comps.get::<TransformStore>(node.uuid),
+				self.node_comps.get::<Mesh>(node.uuid),
+			) {
 				let mvp = transform.absolute;
 
 				for index in &mesh.indices {
 					if let Some(vert) = mesh.vertices.get(*index as usize) {
-						let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 0.0)).xy();
+						let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 1.0)).xy();
 						out = match out {
 							None => Some(Rect::from_point(vert)),
 							Some(rect) => Some(rect.with_union_point(vert)),

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -5,11 +5,14 @@ mod world;
 
 use std::collections::HashMap;
 
+use crate::math::rect::Rect;
+use crate::node::drawables::TexturedMeshComponents;
 use crate::node::{InoxNode, InoxNodeUuid};
 use crate::params::{Param, ParamCtx};
 use crate::physics::{PhysicsCtx, PuppetPhysics};
 use crate::render::RenderCtx;
 
+use glam::Vec4Swizzles;
 use meta::PuppetMeta;
 use transforms::TransformCtx;
 pub use tree::InoxNodeTree;
@@ -166,5 +169,27 @@ impl Puppet {
 		if let Some(render_ctx) = self.render_ctx.as_mut() {
 			render_ctx.update(&self.nodes, &mut self.node_comps);
 		}
+	}
+
+	/// Compute the bounds of the puppet's current state.
+	pub fn bounds(&self) -> Option<Rect> {
+		let mut out = None;
+		for node in self.nodes.iter() {
+			if let Some(tmc) = self.node_comps.get::<TexturedMeshComponents>(node.uuid) {
+				let mvp = tmc.transform;
+
+				for index in &tmc.mesh.indices {
+					if let Some(vert) = tmc.mesh.vertices.get(*index as usize) {
+						let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 0.0)).xy();
+						out = match out {
+							None => Some(Rect::from_point(vert)),
+							Some(rect) => Some(rect.with_union_point(vert)),
+						};
+					}
+				}
+			}
+		}
+
+		out
 	}
 }

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -5,7 +5,7 @@ mod world;
 
 use std::collections::HashMap;
 
-use crate::math::rect::Rect;
+use crate::math::rect::RectBounds;
 use crate::node::components::{Mesh, TransformStore};
 use crate::node::{InoxNode, InoxNodeUuid};
 use crate::params::{Param, ParamCtx};
@@ -172,7 +172,7 @@ impl Puppet {
 	}
 
 	/// Compute the bounds of the puppet's current state.
-	pub fn bounds(&self) -> Option<Rect> {
+	pub fn bounds(&self) -> Option<RectBounds> {
 		let mut out = None;
 		for node in self.nodes.iter() {
 			if let (Some(transform), Some(mesh)) = (

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -181,14 +181,12 @@ impl Puppet {
 			) {
 				let mvp = transform.absolute;
 
-				for index in &mesh.indices {
-					if let Some(vert) = mesh.vertices.get(*index as usize) {
-						let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 1.0)).xy();
-						out = match out {
-							None => Some(Rect::from_point(vert)),
-							Some(rect) => Some(rect.with_union_point(vert)),
-						};
-					}
+				for vert in &mesh.vertices {
+					let vert = mvp.mul_vec4(glam::Vec4::new(vert.x, vert.y, 0.0, 1.0)).xy();
+					out = match out {
+						None => Some(Rect::from_point(vert)),
+						Some(rect) => Some(rect.with_union_point(vert)),
+					};
 				}
 			}
 		}


### PR DESCRIPTION
This also includes a home-grown Rect type, as I didn't see any in Inox's math libraries.

Currently, we calculate puppet bounds as the union of all points, which seems to work well enough for what I'm doing right now.

Normally, I'd keep this code in my own project, but the ECS isn't part of the public API so I can't get at this information normally.