### PR TITLE
Expose various bits of Inox2D state for reading.

### DIFF
--- a/inox2d/src/node.rs
+++ b/inox2d/src/node.rs
@@ -3,9 +3,15 @@ pub mod drawables;
 
 use crate::math::transform::TransformOffset;
 
-#[derive(Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
 #[repr(transparent)]
 pub struct InoxNodeUuid(pub(crate) u32);
+
+impl Into<u32> for InoxNodeUuid {
+	fn into(self) -> u32 {
+		self.0
+	}
+}
 
 pub struct InoxNode {
 	pub uuid: InoxNodeUuid,

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -168,6 +168,10 @@ impl Puppet {
 		}
 	}
 
+	pub fn physics(&self) -> &PuppetPhysics {
+		&self.physics
+	}
+
 	pub fn nodes(&self) -> &InoxNodeTree {
 		&self.nodes
 	}

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -167,4 +167,8 @@ impl Puppet {
 			render_ctx.update(&self.nodes, &mut self.node_comps);
 		}
 	}
+
+	pub fn nodes(&self) -> &InoxNodeTree {
+		&self.nodes
+	}
 }

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -175,4 +175,8 @@ impl Puppet {
 	pub fn nodes(&self) -> &InoxNodeTree {
 		&self.nodes
 	}
+
+	pub fn params(&self) -> &HashMap<String, Param> {
+		&self.params
+	}
 }

--- a/inox2d/src/puppet.rs
+++ b/inox2d/src/puppet.rs
@@ -176,6 +176,10 @@ impl Puppet {
 		&self.nodes
 	}
 
+	pub fn world(&self) -> &World {
+		&self.node_comps
+	}
+
 	pub fn params(&self) -> &HashMap<String, Param> {
 		&self.params
 	}


### PR DESCRIPTION
This was mainly necessary for building a puppet debug tool.

One thing I did not include was a way to create node UUIDs. Currently I'm just transmuting them. I wasn't sure if you were OK with merging that or not. I figured having read-only access to internal state *would* be OK.